### PR TITLE
Fix function handler filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forta-agent-tools",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Forta Agents for common approaches",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/function.calls.spec.ts
+++ b/src/function.calls.spec.ts
@@ -308,4 +308,31 @@ describe("Function calls detector Agent Tests", () => {
     const findings: Finding[] = await handleTransaction(txEvent);
     expect(findings).toStrictEqual([generalTestFindingGenerator(), generalTestFindingGenerator()]);
   });
+
+  it("should filter only by selector if options are undefined", async () => {
+    const functionDefinition: AbiItem = {
+      name: "myMethodWithOutput",
+      type: "function",
+      inputs: [],
+      outputs: [
+        {
+          name: "value",
+          type: "uint256",
+        },
+      ],
+    };
+
+
+    handleTransaction = provideFunctionCallsDetectorHandler(generalTestFindingGenerator, functionDefinition);
+
+    const input: string = encodeFunctionCall(functionDefinition, []);
+    const txEvent: TransactionEvent = new TestTransactionEvent().addTraces({
+      input: input
+    }).addTraces({
+      input: "wrongSelector"
+    });
+
+    const findings: Finding[] = await handleTransaction(txEvent);
+    expect(findings).toStrictEqual([generalTestFindingGenerator()]);
+  });
 });

--- a/src/function.calls.ts
+++ b/src/function.calls.ts
@@ -41,11 +41,11 @@ const fromTraceActionToFunctionCallInfo = (functionSignature: Signature, trace: 
 };
 
 const createFilter = (functionSignature: Signature, options: HandlerOptions | undefined): Filter => {
-  if (options === undefined) {
-    return (_) => true;
-  }
-
   const expectedSelector: string = encodeFunctionSignature(functionSignature);
+
+  if (options === undefined) {
+    return (functionCallInfo: FunctionCallInfo) => expectedSelector === functionCallInfo.functionSelector;
+  }
 
   return (functionCallInfo: FunctionCallInfo) => {
     if (functionCallInfo.arguments === undefined) return false;


### PR DESCRIPTION
The filter use in the `providerFunctionCallDetectorHandler` always returned `true` if options were `undefined`.
Changes:
- Add regression test case.
- Return filter using only `function selector` when options are `undefined`