### PR TITLE
Replace filterEvent with filterLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,15 @@ const handler = provideEventCheckerHandler(findingGenerator, eventSignature, add
 #### Arguments
 
 - `findingGenerator`: The purpose of this argument was explained in the "General Types" section. The function provided as an argument will receive a `metadataVault` with the keys:
-  - `topics`: An array containing the event's topics.
-  - `data`: The event's data
-  - `address`: The address emitting the event.
+  - `eventFragment`: An ethers.js EventFragment object related to the specific event.
+  - `name`: The event name.
+  - `signature`: The event signature.
+  - `topic`: The topic hash.
+  - `args`: The event input parameter values (both index-based and key-based access based on parameter order and names).
+  - `address`: The log originating address.
+- `eventSignature`: The event signature to be detected.
 - `address`: If provided, the approach will only detect events emitted from the specified account.
-- `filter`: If provided, the approach will only detect events that are not discarded by the filter. This function has the type `(log: Log, index?: number, array?: Log[]) => boolean`, it will be used as argument for the common `filter` arrays function.
+- `filter`: If provided, the approach will only detect events that are not discarded by the filter. This function has the type `(log: LogDescription, index?: number, array?: LogDescription[]) => boolean`, it will be used as argument for the common `filter` arrays function.
 
 ### - Eth Transfer Handler
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forta-agent-tools",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "Forta Agents for common approaches",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/erc20.transfers.spec.ts
+++ b/src/erc20.transfers.spec.ts
@@ -23,8 +23,7 @@ const createTransactionEventWithTransferLog = (
   );
 };
 
-// Skiping this test suite because template is outdated
-describe.skip("ERC20 Transfer Agent Tests", () => {
+describe("ERC20 Transfer Agent Tests", () => {
   let handleTransaction: HandleTransaction;
 
   it("should returns empty findings if the expected event wasn't emitted", async () => {

--- a/src/events.checker.ts
+++ b/src/events.checker.ts
@@ -1,42 +1,25 @@
-import { Finding, HandleTransaction, Log, TransactionEvent } from "forta-agent";
+import { Finding, HandleTransaction, LogDescription, TransactionEvent } from "forta-agent";
 import { FindingGenerator } from "./utils";
 
-interface EventData {
-  topics: string[];
-  data: string;
-  address: string;
-}
-
-function eventData(log: Log): EventData {
-  return {
-    topics: log.topics,
-    data: log.data,
-    address: log.address,
-  };
-}
-
-// Deprecated because `filterEvent` is deprecated in Forta SDK
 export default function provideEventCheckerHandler(
   createFinding: FindingGenerator,
   eventSignature: string,
   address?: string,
-  filter?: (log: Log, index?: number, array?: Log[]) => boolean
+  filter?: (log: LogDescription, index?: number, array?: LogDescription[]) => boolean,
 ): HandleTransaction {
   return async (txEvent: TransactionEvent): Promise<Finding[]> => {
     const findings: Finding[] = [];
 
-    // if (filter) {
-    //   txEvent
-    //     .filterEvent(eventSignature, address)
-    //     .filter(filter)
-    //     .map(eventData)
-    //     .map((data: EventData) => findings.push(createFinding(data)));
-    // } else {
-    //   txEvent
-    //     .filterEvent(eventSignature, address)
-    //     .map(eventData)
-    //     .map((data: EventData) => findings.push(createFinding(data)));
-    // }
+    if (filter) {
+      txEvent
+        .filterLog(eventSignature, address)
+        .filter(filter)
+        .forEach((data: LogDescription) => findings.push(createFinding(data)));
+    } else {
+      txEvent
+        .filterLog(eventSignature, address)
+        .forEach((data: LogDescription) => findings.push(createFinding(data)));
+    }
 
     return findings;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-// import provideERC20TransferHandler from "./erc20.transfers";
+import provideERC20TransferHandler from "./erc20.transfers";
 import provideETHTransferHandler from "./eth.transfers";
 import provideFunctionCallsDetectorHandler from "./function.calls";
-// import provideEventCheckerHandler from "./events.checker";
+import provideEventCheckerHandler from "./events.checker";
 import provideBlacklistedAddressesHandler from "./blacklisted.addresses";
 import {
   FindingGenerator,
@@ -23,10 +23,10 @@ import {
 import { TestTransactionEvent, TestBlockEvent, runBlock, createAddress, Agent, TraceProps } from "./tests.utils";
 
 export {
-  // provideERC20TransferHandler,
+  provideERC20TransferHandler,
   provideETHTransferHandler,
   provideFunctionCallsDetectorHandler,
-  // provideEventCheckerHandler,
+  provideEventCheckerHandler,
   provideBlacklistedAddressesHandler,
   createAddress,
   FindingGenerator,


### PR DESCRIPTION
There were some deprecated modules that used the `filterEvent` function to get event data. The usage cases were replaced with the newer `filterLog` function.
Though their objective is similar, they have some differences:
- Instead of using the usual event signature (e.g. `Event(uint256)`, the newer version uses the abi specification (e.g. `event Event(uint256 value)`);
- Related to the previous point, the Forta SDK `filterLog` uses `ethers.js` `parseLog` function, which returns a LogDescription object. This has some features like an `args` array with the expected parameter types and also keys based on the parameter names;
- It simply doesn't work filtering an event with the right signature but wrong data or topics: whereas `filterEvent` did catch the event anyway, `filterLog` does not.

There are some changes in both erc20 transfers and event checker modules related, basically, to these three topics.