### PR TITLE
Change default event data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forta-agent-tools",
-  "version": "1.0.38",
+  "version": "1.0.40",
   "description": "Forta Agents for common approaches",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/tests.utils.ts
+++ b/src/tests.utils.ts
@@ -115,7 +115,7 @@ export class TestTransactionEvent extends TransactionEvent {
   public addEventLog(
     eventSignature: string | AbiItem,
     address: string = createAddress("0x0"),
-    data: string = "",
+    data: string = "0x",
     ...topics: string[]
   ): TestTransactionEvent {
     this.receipt.logs.push({
@@ -128,7 +128,7 @@ export class TestTransactionEvent extends TransactionEvent {
 
   public addAnonymousEventLog(
     address: string = createAddress("0x0"),
-    data: string = "",
+    data: string = "0x",
     ...topics: string[]
   ): TestTransactionEvent {
     this.receipt.logs.push({


### PR DESCRIPTION
I propose we change the default `data` parameter on the `addEventLog` function to `"0x"` instead of `""`. With this, an event with no arguments can be monitored just by using `addEventLog(EVENT_SIGNATURE, ADDRESS)`, instead of having to set a `data` parameter.

Asking for review before changing the package version to avoid any conflicts.