### PR TITLE
Add NetworkManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,9 @@ const data: Record<number, NetworkData> = {
 };
 
 const provider = getEthersProvider();
-const networkManager = new NetworkManager(data, provider);
+const networkManager = new NetworkManager(data);
 
-await networkManager.init();
+await networkManager.init(provider);
 
 networkManager.get("address"); // "address1" if the ChainID is 1, "address42" if the ChainID is 42
 ```

--- a/README.md
+++ b/README.md
@@ -300,3 +300,45 @@ This mock provides some methods to set up the values that the signer should retu
 - `denyTransaction(from, to, iface, id, inputs, msg)`. Same conditions of `allowTransaction` but in this case the transaction will be reverted with `msg` message.
 
 All the data you set in the signer will be used until the `clear` function is called.
+
+### NetworkManager
+
+This is a tool to help with storing data relative to the network the bot will be running at.
+
+Basic usage:
+```ts
+import { NetworkManager } from "forta-agent-tools";
+
+interface NetworkData {
+  address: string;
+  num: number;
+}
+
+const data: Record<number, NetworkData> = {
+  // ChainID 1
+  1: {
+    address: "address1",
+    num: 1,
+  },
+  42: {
+    address: "address42",
+    num: 2,
+  },
+};
+
+const provider = getEthersProvider();
+const networkManager = new NetworkManager(data, provider);
+
+await networkManager.init();
+
+networkManager.get("address"); // "address1" if the ChainID is 1, "address42" if the ChainID is 42
+```
+
+#### How to use it
+
+- `NetworkManager(networkData, chainId?)`: Sets the network data and creates a `NetworkManager` instance. If `chainId` is specified, it won't need `NetworkManager.init()` to be initialized. Throws an error if there is no entry for `chainId` in `networkData`.
+- `getNetworkMap()`: Gets the network map passed as argument in the constructor as read-only.
+- `getNetwork()`: Gets the instance's active ChainID.
+- `setNetwork(chainId)`: Sets the instance's active ChainID. Throws an error if there is no entry for `chainId` in `networkData`.
+- `init(provider)`: Retrieves network data from the provider and sets the active ChainID. Throws an error if there is no entry for that ChainID in `networkData`.
+- `get(key)`: Gets the value of the field `key` in the active network's data record. Throws an error if `NetworkManager` was not yet initialized, i.e. the ChainID was not specified in the constructor and `NetworkManager.init()` or `NetworkManager.setNetwork()` were not called.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forta-agent-tools",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "Forta Agents for common approaches",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
   encodeFunctionSignature,
   encodeEventSignature,
 } from "./utils";
+import NetworkManager from "./network.manager";
 
 export {
   provideERC20TransferHandler,
@@ -30,6 +31,7 @@ export {
   encodeEventSignature,
   encodeFunctionSignature,
   FindingGenerator,
+  NetworkManager,
 };
 
 export default {

--- a/src/network.manager.spec.ts
+++ b/src/network.manager.spec.ts
@@ -1,0 +1,119 @@
+import { ethers } from "forta-agent";
+import { MockEthersProvider } from "./tests";
+import NetworkManager from "./network.manager";
+
+enum Network {
+  ETHEREUM_MAINNET = 1,
+  POLYGON = 137,
+  ARBITRUM = 42161,
+}
+
+describe("NetworkManager test suite", () => {
+  describe("constructor", () => {
+    it("should leave the network as -1 if no chainId was specified", () => {
+      const networkManager = new NetworkManager({});
+
+      expect(networkManager.getNetworkMap()).toStrictEqual({});
+      expect(networkManager.getNetwork()).toStrictEqual(-1);
+    });
+
+    it("should check if the specified chainId is supported and throw errors accordingly", () => {
+      const data = {
+        [Network.ETHEREUM_MAINNET]: {
+          test: "test",
+        },
+      };
+
+      let networkManager: NetworkManager<{ test: string }>;
+
+      expect(() => {
+        networkManager = new NetworkManager(data, Network.ETHEREUM_MAINNET);
+      }).not.toThrowError(`The network with ID ${Network.ETHEREUM_MAINNET} is not supported`);
+      expect(networkManager!.getNetworkMap()).toStrictEqual(data);
+      expect(networkManager!.getNetwork()).toStrictEqual(Network.ETHEREUM_MAINNET);
+
+      expect(() => {
+        networkManager = new NetworkManager(data, Network.POLYGON);
+      }).toThrowError(`The network with ID ${Network.POLYGON} is not supported`);
+    });
+  });
+
+  describe("init", () => {
+    let provider: ethers.providers.Provider;
+    let chainId: number;
+
+    beforeAll(() => {
+      chainId = Network.ETHEREUM_MAINNET;
+
+      const mockProvider = new MockEthersProvider();
+      // @ts-expect-error
+      mockProvider.getNetwork = jest.fn().mockImplementation(() => ({ chainId }));
+
+      provider = mockProvider as unknown as ethers.providers.Provider;
+    });
+
+    it("should check if the fetched chainId is supported and throw errors accordingly", async () => {
+      const data = {
+        [Network.ETHEREUM_MAINNET]: {
+          test: "test",
+        },
+      };
+
+      const networkManager = new NetworkManager(data);
+
+      await expect(networkManager.init(provider)).resolves.toBeUndefined();
+      expect(networkManager.getNetwork()).toStrictEqual(Network.ETHEREUM_MAINNET);
+
+      chainId = Network.POLYGON;
+
+      await expect(networkManager.init(provider)).rejects.toThrowError(
+        `The network with ID ${chainId} is not supported`
+      );
+    });
+  });
+
+  describe("set network", () => {
+    it("should check if the specified chainId is supported and throw errors accordingly", () => {
+      const data = {
+        [Network.ETHEREUM_MAINNET]: {
+          test: "test",
+        },
+        [Network.POLYGON]: {
+          test: "test",
+        },
+      };
+
+      let networkManager = new NetworkManager(data);
+      expect(() => {
+        networkManager.setNetwork(Network.ETHEREUM_MAINNET);
+      }).not.toThrowError(`The network with ID ${Network.ETHEREUM_MAINNET} is not supported`);
+      expect(() => {
+        networkManager.setNetwork(Network.POLYGON);
+      }).not.toThrowError(`The network with ID ${Network.POLYGON} is not supported`);
+      expect(() => {
+        networkManager.setNetwork(Network.ARBITRUM);
+      }).toThrowError(`The network with ID ${Network.ARBITRUM} is not supported`);
+    });
+  });
+
+  describe("get", () => {
+    it("should get the correct value for a key according to the network", () => {
+      const data = {
+        [Network.ETHEREUM_MAINNET]: {
+          test: "Ethereum",
+        },
+        [Network.POLYGON]: {
+          test: "Polygon",
+        },
+      };
+
+      const networkManager = new NetworkManager(data, Network.ETHEREUM_MAINNET);
+
+      expect(networkManager.get("test")).toStrictEqual("Ethereum");
+
+      networkManager.setNetwork(Network.POLYGON);
+
+      expect(networkManager.get("test")).toStrictEqual("Polygon");
+    });
+  });
+});

--- a/src/network.manager.ts
+++ b/src/network.manager.ts
@@ -1,0 +1,39 @@
+import { ethers } from "forta-agent";
+
+export default class NetworkManager<T extends Record<any, any>> {
+  private chainId: number = -1;
+
+  constructor(private networkMap: Record<number, T>, chainId?: number) {
+    if (chainId !== undefined) {
+      this.setNetwork(chainId);
+    }
+  }
+
+  public getNetworkMap(): Readonly<Record<number, T>> {
+    return this.networkMap;
+  }
+
+  public getNetwork() {
+    return this.chainId;
+  }
+
+  public setNetwork(chainId: number) {
+    if (!this.networkMap[chainId]) {
+      throw new Error(`The network with ID ${chainId} is not supported`);
+    }
+
+    this.chainId = chainId;
+  }
+
+  public async init(provider: ethers.providers.Provider) {
+    const { chainId } = await provider.getNetwork();
+
+    this.setNetwork(chainId);
+  }
+
+  public get<K extends keyof T>(key: K): T[K] {
+    if (this.chainId === -1) throw new Error("NetworkManager was not initialized");
+
+    return this.networkMap[this.chainId][key];
+  }
+}


### PR DESCRIPTION
This PR adds a generic implementation of `NetworkManager` to help with managing network-specific data in bots.