### PR TITLE
Fix logs filtering bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forta-agent-tools",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Forta Agents for common approaches",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/mock.utils.spec.ts
+++ b/src/mock.utils.spec.ts
@@ -136,7 +136,11 @@ describe("Ethers mocks tests", () => {
           { topics: [EVENT_1_SIGHASH] },
           { topics: [EVENT_2_SIGHASH] },
         ],
-        expected: [{ topics: [EVENT_1_SIGHASH] }, { topics: [EVENT_2_SIGHASH] }],
+        expected: [
+          { topics: [EVENT_1_SIGHASH, EVENT_2_SIGHASH] },
+          { topics: [EVENT_1_SIGHASH] },
+          { topics: [EVENT_2_SIGHASH] },
+        ],
       },
       {
         filter: {

--- a/src/mock.utils.ts
+++ b/src/mock.utils.ts
@@ -108,7 +108,7 @@ export class MockEthersProvider {
       const filterTopics = filter.topics!;
 
       logs = logs.filter((log) => {
-        if (filterTopics.length !== log.topics.length) {
+        if (filterTopics.length > log.topics.length) {
           return false;
         }
 


### PR DESCRIPTION
Actually, the check related to the log topics length isn't a `!==`, it's a `>`, because unspecified topics in a filter are just ignored.