### PR TITLE
Add setParentHash to TestBlockEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forta-agent-tools",
-  "version": "2.2.1",
+  "version": "2.3.1",
   "description": "Forta Agents for common approaches",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/tests.utils.ts
+++ b/src/tests.utils.ts
@@ -207,6 +207,11 @@ export class TestBlockEvent extends BlockEvent {
     return this;
   }
 
+  public setParentHash(blockHash: string): TestBlockEvent {
+    this.block.parentHash = blockHash;
+    return this;
+  }
+
   public setTimestamp(timestamp: number): TestBlockEvent {
     this.block.timestamp = timestamp;
     return this;


### PR DESCRIPTION
Considering the possibility of using mainly block hashes for queries, this PR adds `setParentHash` to `TestBlockEvent` to allow mocking in unit tests cases in which the previous block's hash is needed.