### PR TITLE
feat: add Erc721TransfersHandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "tsc",
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json",
-    "lint-fix": "tslint -p tsconfig.json --fix"
+    "lint-fix": "tslint -p tsconfig.json --fix",
+    "prepare": "tsc"
   },
   "keywords": [],
   "author": "Nethermind",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
-    "lib/**/*"
+    "lib/**/*",
+    "src/**/*"
   ],
   "scripts": {
     "test": "jest",

--- a/src/handler/erc20.transfers.ts
+++ b/src/handler/erc20.transfers.ts
@@ -68,7 +68,7 @@ class Erc20Transfers extends Handler<Erc20Transfers.Options, Erc20Transfers.Meta
         .filterLog(EVENT_SIGNATURE)
         .filter(this.filter)
         .map((log) => ({
-          emitter: log.args.emitter,
+          emitter: log.args.emitter || log.address,
           from: log.args.from,
           to: log.args.to,
           amount: log.args.amount,

--- a/src/handler/erc721.transfers.ts
+++ b/src/handler/erc721.transfers.ts
@@ -72,7 +72,7 @@ class Erc721Transfers extends Handler<Erc721Transfers.Options, Erc721Transfers.M
     };
   }
 
-  public async metadata(event: TransactionEvent | BlockEvent): Promise<Erc20Transfers.Metadata[] | null> {
+  public async metadata(event: TransactionEvent | BlockEvent): Promise<Erc721Transfers.Metadata[] | null> {
     if (event instanceof BlockEvent) {
       return null;
     } else {

--- a/src/handler/erc721.transfers.ts
+++ b/src/handler/erc721.transfers.ts
@@ -1,0 +1,93 @@
+import { LogDescription, TransactionEvent, ethers, BlockEvent } from "forta-agent";
+import { Handler, HandlerOptions } from "./handler";
+
+const EVENT_SIGNATURE = "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)";
+
+namespace Erc721Transfers {
+  export interface Options {
+    emitter?: string;
+    from?: string;
+    to?: string;
+    tokenId?: ethers.BigNumberish | ((amount: ethers.BigNumber) => boolean);
+    amountThreshold?: ethers.BigNumberish | ((amount: ethers.BigNumber) => boolean);
+  }
+
+  export interface Metadata {
+    emitter: string;
+    from: string;
+    to: string;
+    tokenId: ethers.BigNumber;
+    amount: ethers.BigNumber;
+  }
+}
+
+class Erc721Transfers extends Handler<Erc721Transfers.Options, Erc721Transfers.Metadata> {
+  filter: (log: LogDescription) => boolean;
+
+  constructor(options: HandlerOptions<Erc721Transfers.Options, Erc721Transfers.Metadata>) {
+    super(options);
+
+    this.filter = this._createFilter();
+
+    if (this.options.emitter) this.options.emitter = this.options.emitter.toLowerCase();
+    if (this.options.from) this.options.from = this.options.from.toLowerCase();
+    if (this.options.to) this.options.to = this.options.to.toLowerCase();
+  }
+
+  private _createFilter(): (log: LogDescription) => boolean {
+    return (log) => {
+      if (this.options.emitter !== undefined && this.options.emitter !== log.address) {
+        return false;
+      }
+
+      if (this.options.from !== undefined && this.options.from !== log.args.from) {
+        return false;
+      }
+
+      if (this.options.to !== undefined && this.options.to !== log.args.to) {
+        return false;
+      }
+
+      if (this.options.tokenId !== undefined) {
+        if (typeof this.options.tokenId === "function" && !this.options.tokenId(log.args.tokenId)) {
+          return false;
+        }
+
+        if (typeof this.options.tokenId !== "function" && !log.args.tokenId.eq(this.options.tokenId)) {
+          return false;
+        }
+      }
+
+      if (this.options.amountThreshold !== undefined) {
+        if (typeof this.options.amountThreshold === "function" && !this.options.amountThreshold(log.args.amount)) {
+          return false;
+        }
+
+        if (typeof this.options.amountThreshold !== "function" && log.args.amount.lt(this.options.amountThreshold)) {
+          return false;
+        }
+      }
+
+      return true;
+    };
+  }
+
+  public async metadata(event: TransactionEvent | BlockEvent): Promise<Erc20Transfers.Metadata[] | null> {
+    if (event instanceof BlockEvent) {
+      return null;
+    } else {
+      return event
+        .filterLog(EVENT_SIGNATURE)
+        .filter(this.filter)
+        .map((log) => ({
+          emitter: log.args.emitter || log.address,
+          from: log.args.from,
+          to: log.args.to,
+          tokenId: log.args.tokenId,
+          amount: log.args.amount,
+        })) as Erc721Transfers.Metadata[];
+    }
+  }
+}
+
+export default Erc721Transfers;

--- a/src/handler/erc721.transfers.ts
+++ b/src/handler/erc721.transfers.ts
@@ -8,8 +8,7 @@ namespace Erc721Transfers {
     emitter?: string;
     from?: string;
     to?: string;
-    tokenId?: ethers.BigNumberish | ((amount: ethers.BigNumber) => boolean);
-    amountThreshold?: ethers.BigNumberish | ((amount: ethers.BigNumber) => boolean);
+    tokenId?: ethers.BigNumberish | ((tokenId: ethers.BigNumber) => boolean);
   }
 
   export interface Metadata {
@@ -17,7 +16,6 @@ namespace Erc721Transfers {
     from: string;
     to: string;
     tokenId: ethers.BigNumber;
-    amount: ethers.BigNumber;
   }
 }
 
@@ -58,16 +56,6 @@ class Erc721Transfers extends Handler<Erc721Transfers.Options, Erc721Transfers.M
         }
       }
 
-      if (this.options.amountThreshold !== undefined) {
-        if (typeof this.options.amountThreshold === "function" && !this.options.amountThreshold(log.args.amount)) {
-          return false;
-        }
-
-        if (typeof this.options.amountThreshold !== "function" && log.args.amount.lt(this.options.amountThreshold)) {
-          return false;
-        }
-      }
-
       return true;
     };
   }
@@ -84,7 +72,6 @@ class Erc721Transfers extends Handler<Erc721Transfers.Options, Erc721Transfers.M
           from: log.args.from,
           to: log.args.to,
           tokenId: log.args.tokenId,
-          amount: log.args.amount,
         })) as Erc721Transfers.Metadata[];
     }
   }

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -1,6 +1,7 @@
 import Erc20Transfers from "./erc20.transfers";
+import Erc721Transfers from "./erc721.transfers";
 import EthTransfers from "./eth.transfers";
 import TraceCalls from "./trace.calls";
 import BlacklistedAddresses from "./blacklisted.addresses";
 
-export { Erc20Transfers, EthTransfers, TraceCalls, BlacklistedAddresses };
+export { Erc20Transfers, Erc721Transfers, EthTransfers, TraceCalls, BlacklistedAddresses };


### PR DESCRIPTION
This PR adds `Erc721TransfersHandler` and fix bugs in `Erc20TransfersHandler`. In addition, a `prepare` script is added to the `package.json` so that users can directly install this package through github (e.g. `npm install git+https://github.com/NethermindEth/general-agents-module.git`)