### PR TITLE
Victim Identifier Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,8 +708,17 @@ async function getBalances() {
 
 This is a class library that identifies protocol victims:
 
-- 1. during the preparation stage of an attack, where victims are contained in a newly deployed contract's code
-- 2. during the exploitation stage of an attack, in transactions where the victim protocol's balance, denominated in USD, is reduced.
+1.  during the preparation stage of an attack, where victims are contained in a newly deployed contract's code
+2.  during the exploitation stage of an attack, in transactions where the victim protocol's balance is reduced:
+    - more than $100, when denominated in USD, or
+    - more than 5% of the token's total supply.
+
+The library also calculates the `Confidence Level` (0-1) for each of the victims:
+
+- Preparation stage:
+  - The `Confidence Level` is determined based on the number of occurrences of the victim address in previously deployed contracts code.
+- Exploitation stage:
+  - The `Confidence Level` is determined either based on the USD value (with $500000 or more being the CL: 1 and by then splitting the CL into 10 parts) or based on the percentage of the token's total supply in which case there are 4 levels of confidence (5%-9%: CL 0.7, 10%-19%: CL 0.8, 20-29%%: CL 0.9, >30%: CL 1)
 
 Supported chains:
 

--- a/README.md
+++ b/README.md
@@ -707,8 +707,9 @@ async function getBalances() {
 ### VictimIdentifier
 
 This is a class library that identifies protocol victims:
-* 1) during the preparation stage of an attack, where victims are contained in a newly deployed contract's code
-* 2) during the exploitation stage of an attack, in transactions where the victim protocol's balance, denominated in USD, is reduced.
+
+- 1. during the preparation stage of an attack, where victims are contained in a newly deployed contract's code
+- 2. during the exploitation stage of an attack, in transactions where the victim protocol's balance, denominated in USD, is reduced.
 
 Supported chains:
 
@@ -745,7 +746,24 @@ export const provideHandleTransaction =
     const findings: Finding[] = [];
 
     const victims = await victimsIdentifier.getIdentifiedVictims(txEvent);
-    //Returns a Record<string, {protocolUrl: string; protocolTwitter: string; tag: string; holders: string[];}>
+    /*Returns an object of type: 
+    {
+      exploitationStage: Record<string, {
+          protocolUrl: string;
+          protocolTwitter: string;
+          tag: string;
+          holders: string[];
+          confidence: number;
+      }>;
+      preparationStage: Record<string, {
+          protocolUrl: string;
+          protocolTwitter: string;
+          tag: string;
+          holders: string[];
+          confidence: number;
+      }>;
+    }
+    */
 
     // Rest of the logic
     return findings;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forta-agent-tools",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "forta-agent-tools",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@ethersproject/properties": "^5.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ethersproject/properties": "^5.6.0",
         "@ethersproject/transactions": "^5.6.2",
+        "@openzeppelin/upgrades-core": "^1.20.6",
         "@types/node-fetch": "^2.6.2",
         "async-mutex": "^0.3.2",
         "ethers-multicall": "^0.2.3",
@@ -1653,6 +1654,20 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@openzeppelin/upgrades-core": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.20.6.tgz",
+      "integrity": "sha512-KWdtlahm+iunlAlzLsdpBueanwEx0LLPfAkDL1p0C4SPjMiUqHHFlyGtmmWwdiqDpJ//605vfwkd5RqfnFrHSg==",
+      "dependencies": {
+        "cbor": "^8.0.0",
+        "chalk": "^4.1.0",
+        "compare-versions": "^5.0.0",
+        "debug": "^4.1.1",
+        "ethereumjs-util": "^7.0.3",
+        "proper-lockfile": "^4.1.1",
+        "solidity-ast": "^0.4.15"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1768,6 +1783,14 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -1835,10 +1858,26 @@
         "form-data": "^3.0.0"
       }
     },
+    "node_modules/@types/pbkdf2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg=="
+    },
+    "node_modules/@types/secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -2128,6 +2167,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base-x": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2151,6 +2198,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -2285,6 +2337,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -2374,6 +2444,17 @@
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
       ]
+    },
+    "node_modules/cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12.19"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2479,6 +2560,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "node_modules/compare-versions": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
+      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2823,6 +2909,43 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "dependencies": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/ethereumjs-util": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+      "dependencies": {
+        "@types/bn.js": "^5.1.0",
+        "bn.js": "^5.1.2",
+        "create-hash": "^1.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "rlp": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/ethers": {
@@ -4592,6 +4715,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4868,6 +4999,24 @@
         "node": ">= 6"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
@@ -5070,6 +5219,17 @@
         "inherits": "^2.0.1"
       }
     },
+    "node_modules/rlp": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      },
+      "bin": {
+        "rlp": "bin/rlp"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5131,6 +5291,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -5212,6 +5377,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/solidity-ast": {
+      "version": "0.4.40",
+      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.40.tgz",
+      "integrity": "sha512-M8uLBT2jgFB7B0iVAC5a2l71J8vim7aEm03AZkaHbDqyrl1pE+i5PriMEw6WlwGfHp3/Ym7cn9BqvVLQgRk+Yw=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -7090,6 +7260,20 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@openzeppelin/upgrades-core": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades-core/-/upgrades-core-1.20.6.tgz",
+      "integrity": "sha512-KWdtlahm+iunlAlzLsdpBueanwEx0LLPfAkDL1p0C4SPjMiUqHHFlyGtmmWwdiqDpJ//605vfwkd5RqfnFrHSg==",
+      "requires": {
+        "cbor": "^8.0.0",
+        "chalk": "^4.1.0",
+        "compare-versions": "^5.0.0",
+        "debug": "^4.1.1",
+        "ethereumjs-util": "^7.0.3",
+        "proper-lockfile": "^4.1.1",
+        "solidity-ast": "^0.4.15"
+      }
+    },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -7202,6 +7386,14 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bn.js": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -7269,10 +7461,26 @@
         "form-data": "^3.0.0"
       }
     },
+    "@types/pbkdf2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/prettier": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg=="
+    },
+    "@types/secp256k1": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
+      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -7506,6 +7714,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base-x": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7515,6 +7731,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
+    "blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
     "bn.js": {
       "version": "5.2.1",
@@ -7627,6 +7848,24 @@
         "fast-json-stable-stringify": "2.x"
       }
     },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -7683,6 +7922,14 @@
       "version": "1.0.30001441",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
       "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg=="
+    },
+    "cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "requires": {
+        "nofilter": "^3.1.0"
+      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -7763,6 +8010,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
+    },
+    "compare-versions": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
+      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -8043,6 +8295,40 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "requires": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "ethereumjs-util": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+      "requires": {
+        "@types/bn.js": "^5.1.0",
+        "bn.js": "^5.1.2",
+        "create-hash": "^1.1.2",
+        "ethereum-cryptography": "^0.1.3",
+        "rlp": "^2.2.4"
+      }
     },
     "ethers": {
       "version": "5.7.2",
@@ -9399,6 +9685,11 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
       "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
+    "nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g=="
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -9596,6 +9887,23 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
+        }
+      }
+    },
     "protobufjs": {
       "version": "6.11.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
@@ -9756,6 +10064,14 @@
         "inherits": "^2.0.1"
       }
     },
+    "rlp": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+      "requires": {
+        "bn.js": "^5.2.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -9793,6 +10109,11 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -9853,6 +10174,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+    },
+    "solidity-ast": {
+      "version": "0.4.40",
+      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.40.tgz",
+      "integrity": "sha512-M8uLBT2jgFB7B0iVAC5a2l71J8vim7aEm03AZkaHbDqyrl1pE+i5PriMEw6WlwGfHp3/Ym7cn9BqvVLQgRk+Yw=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@ethersproject/properties": "^5.6.0",
     "@ethersproject/transactions": "^5.6.2",
     "@types/node-fetch": "^2.6.2",
+    "@openzeppelin/upgrades-core": "^1.20.6",
     "async-mutex": "^0.3.2",
     "ethers-multicall": "^0.2.3",
     "evm": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forta-agent-tools",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Forta Agents for common approaches",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/utils/victim-identification/helpers/constants.ts
+++ b/src/utils/victim-identification/helpers/constants.ts
@@ -1,5 +1,7 @@
 import { ethers } from "forta-agent";
 
+export const MAX_USD_VALUE = 500000;
+
 export const wrappedNativeTokens: Record<number, string> = {
   1: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   10: "0x4200000000000000000000000000000000000006",

--- a/src/utils/victim-identification/helpers/constants.ts
+++ b/src/utils/victim-identification/helpers/constants.ts
@@ -10,7 +10,7 @@ export const wrappedNativeTokens: Record<number, string> = {
   43114: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
 };
 
-export const PREPARATION_BOT = ["0x0b241032ca430d9c02eaa6a52d217bbff046f0d1b3f3d2aa928e42a97150ec91"]; // suspicious contract creation
+export const PREPARATION_BOT = ["0x0b241032ca430d9c02eaa6a52d217bbff046f0d1b3f3d2aa928e42a97150ec91"]; // Malicious Contract Creation ML Bot v2
 export const SUBGRAPH_URL = "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3";
 
 export const ZERO = ethers.constants.Zero;

--- a/src/utils/victim-identification/helpers/constants.ts
+++ b/src/utils/victim-identification/helpers/constants.ts
@@ -23,6 +23,7 @@ export const TOKEN_ABI = [
   "function symbol() external view returns (string)",
   "function name() public view returns (string)",
   "function decimals() external view returns (uint8)",
+  "function totalSupply() external view returns (uint256)",
 ];
 
 export const MKR_TOKEN_ABI = ["function symbol() external view returns (bytes32)"];

--- a/src/utils/victim-identification/helpers/helper.ts
+++ b/src/utils/victim-identification/helpers/helper.ts
@@ -198,7 +198,9 @@ export const getContractName = async (provider: ethers.providers.JsonRpcProvider
         result = (await (await fetch(url)).json()) as any;
 
         if (result.message.startsWith("NOTOK")) {
-          console.log(`block explorer error occured; skipping contract name check for ${address}`);
+          console.log(
+            `block explorer error occurred; skipping contract name check for implentation address at ${address}`
+          );
           return "Not Found";
         }
 

--- a/src/utils/victim-identification/helpers/helper.ts
+++ b/src/utils/victim-identification/helpers/helper.ts
@@ -206,10 +206,10 @@ export const getContractName = async (provider: ethers.providers.JsonRpcProvider
         if (contractName === "") {
           return "Not Found";
         }
-      }
-    }
 
-    return contractName;
+        return contractName;
+      } else return "Not Found";
+    } else return contractName;
   } catch {
     return "Not Found";
   }

--- a/src/utils/victim-identification/helpers/token.info.fetcher.spec.ts
+++ b/src/utils/victim-identification/helpers/token.info.fetcher.spec.ts
@@ -46,6 +46,15 @@ const TEST_DECIMALS: [number, number][] = [
   [50, 9],
 ];
 
+// [blockNumber, token, totalSupply]
+const TEST_TOTAL_SUPPLIES: [number, string, BigNumber][] = [
+  [10, createAddress("0xa1"), BigNumber.from(100)],
+  [20, createAddress("0xa2"), BigNumber.from(1000)],
+  [30, createAddress("0xa3"), BigNumber.from(10000)],
+  [40, createAddress("0xa4"), BigNumber.from(100000)],
+  [50, createAddress("0xa5"), BigNumber.from(1000000)],
+];
+
 const TEST_BLOCK = 120;
 const PROTOCOL_ADDRESS = createAddress("0xa1");
 const tokenAddress = createAddress("0xa2");
@@ -77,12 +86,34 @@ describe("TokenInfoFetcher tests suite", () => {
 
     // clear mockProvider to use cache
     mockProvider.clear();
-    mockProvider;
     for (let [block, balance] of TEST_BALANCES) {
       const fetchedBalance = await fetcher.getBalance(block, PROTOCOL_ADDRESS, tokenAddress);
       expect(fetchedBalance).toStrictEqual(balance);
     }
     expect(mockProvider.call).toBeCalledTimes(6);
+    mockProvider.clear();
+  });
+
+  it("should fetch total supply and use cache correctly", async () => {
+    for (let [block, token, totalSupply] of TEST_TOTAL_SUPPLIES) {
+      mockProvider.addCallTo(token, block, TOKEN_IFACE, "totalSupply", {
+        inputs: [],
+        outputs: [totalSupply],
+      });
+
+      const fetchedTotalSupply = await fetcher.getTotalSupply(block, token);
+      expect(fetchedTotalSupply).toStrictEqual(totalSupply);
+    }
+    expect(mockProvider.call).toBeCalledTimes(5);
+
+    // clear mockProvider to use cache
+    mockProvider.clear();
+    for (let [block, token, totalSupply] of TEST_TOTAL_SUPPLIES) {
+      const fetchedTotalSupply = await fetcher.getTotalSupply(block, token);
+      expect(fetchedTotalSupply).toStrictEqual(totalSupply);
+    }
+    expect(mockProvider.call).toBeCalledTimes(5);
+
     mockProvider.clear();
   });
 

--- a/src/utils/victim-identification/helpers/token.info.fetcher.ts
+++ b/src/utils/victim-identification/helpers/token.info.fetcher.ts
@@ -16,7 +16,7 @@ import {
 import fetch from "node-fetch";
 
 export default class TokenInfoFetcher {
-  provider: providers.Provider;
+  provider: providers.JsonRpcProvider;
   private cache: LRU<string, BigNumber | number | string>;
   private tokensPriceCache: LRU<string, number>;
   private tokenContract: Contract;

--- a/src/utils/victim-identification/helpers/token.info.fetcher.ts
+++ b/src/utils/victim-identification/helpers/token.info.fetcher.ts
@@ -47,6 +47,21 @@ export default class TokenInfoFetcher {
     return balance;
   }
 
+  public async getTotalSupply(block: number, tokenAddress: string): Promise<BigNumber> {
+    const token = this.tokenContract.attach(tokenAddress);
+
+    const key: string = `totalSupply-${tokenAddress}-${block}`;
+    if (this.cache.has(key)) return this.cache.get(key) as BigNumber;
+
+    const totalSupply: BigNumber = await token.totalSupply({
+      blockTag: block,
+    });
+
+    this.cache.set(key, totalSupply);
+
+    return totalSupply;
+  }
+
   public async getSymbolOrName(chainId: number, block: number | string, tokenAddress: string): Promise<string> {
     const token = this.tokenContract.attach(tokenAddress);
     const key: string = `symbol-${chainId}-${tokenAddress}-${block}`;

--- a/src/utils/victim-identification/victim.identifier.spec.ts
+++ b/src/utils/victim-identification/victim.identifier.spec.ts
@@ -19,6 +19,12 @@ jest.mock("forta-agent", () => {
   };
 });
 
+jest.mock("@openzeppelin/upgrades-core", () => {
+  return {
+    getImplementationAddressFromProxy: jest.fn().mockResolvedValue("0x1234567890"),
+  };
+});
+
 jest.mock("node-fetch");
 const { Response } = jest.requireActual("node-fetch");
 
@@ -633,6 +639,16 @@ describe("Victim Identifier tests suite", () => {
         return Promise.reject(new Response(JSON.stringify({})));
       } else if (callCount === 4) {
         // Not mocking an ERC20 symbol/name call implying a failed call, so it then fetches the contract name
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              message: "OOOK",
+              result: [{ ContractName: "proxyyyyyy" }],
+            })
+          )
+        );
+      } else if (callCount === 5) {
+        // Call to the block explorer API to fetch the implementation contract name
         return Promise.resolve(
           new Response(
             JSON.stringify({

--- a/src/utils/victim-identification/victim.identifier.spec.ts
+++ b/src/utils/victim-identification/victim.identifier.spec.ts
@@ -182,7 +182,7 @@ describe("Victim Identifier tests suite", () => {
 
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(mockGetAlerts).toHaveBeenCalled();
-    expect(victims).toEqual({});
+    expect(victims).toEqual({ exploitationStage: {}, preparationStage: {} });
   });
 
   it("should not fetch the past alerts twice in the same block", async () => {
@@ -210,13 +210,13 @@ describe("Victim Identifier tests suite", () => {
 
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(mockGetAlerts).toHaveBeenCalledTimes(1);
-    expect(victims).toEqual({});
+    expect(victims).toEqual({ exploitationStage: {}, preparationStage: {} });
 
     mockGetAlerts.mockClear();
     const mockTxEvent2 = new TestTransactionEvent().setBlock(21123);
     const victims2 = await victimIdentifier.getIdentifiedVictims(mockTxEvent2);
     expect(mockGetAlerts).not.toHaveBeenCalled();
-    expect(victims2).toEqual({});
+    expect(victims2).toEqual({ exploitationStage: {}, preparationStage: {} });
   });
 
   it("should return preparation stage victims correctly when the tag can be found", async () => {
@@ -228,9 +228,14 @@ describe("Victim Identifier tests suite", () => {
       alerts: [
         {
           metadata: {
-            address1: createAddress("0x1234"),
-            address1again: createAddress("0x1234"),
-            address2: createAddress("0x5678"),
+            // Add 10 occurrences of the "0x1234"
+            ...Object.assign(
+              {},
+              ...Array.from({ length: 10 }, (_, i) => ({
+                [`address${i}`]: createAddress("0x1234"),
+              }))
+            ),
+            address10: createAddress("0x5678"),
           },
         },
       ],
@@ -317,17 +322,22 @@ describe("Victim Identifier tests suite", () => {
 
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(victims).toStrictEqual({
-      "0x0000000000000000000000000000000000005678": {
-        holders: ["0x000000000000000000000000000000000022aabb", "0x0000000000000000000000000000000033aabbcc"],
-        protocolTwitter: "Victim5678Twitter",
-        protocolUrl: "victim5678.org",
-        tag: "Victim5678",
-      },
-      "0x0000000000000000000000000000000000001234": {
-        holders: ["0x000000000000000000000000000000000044aabb", "0x0000000000000000000000000000000055aabbcc"],
-        protocolTwitter: "Victim1234Twitter",
-        protocolUrl: "victim1234.org",
-        tag: "Victim1234",
+      exploitationStage: {},
+      preparationStage: {
+        "0x0000000000000000000000000000000000005678": {
+          holders: ["0x000000000000000000000000000000000022aabb", "0x0000000000000000000000000000000033aabbcc"],
+          protocolTwitter: "Victim5678Twitter",
+          protocolUrl: "victim5678.org",
+          tag: "Victim5678",
+          confidence: 0.6,
+        },
+        "0x0000000000000000000000000000000000001234": {
+          holders: ["0x000000000000000000000000000000000044aabb", "0x0000000000000000000000000000000055aabbcc"],
+          protocolTwitter: "Victim1234Twitter",
+          protocolUrl: "victim1234.org",
+          tag: "Victim1234",
+          confidence: 0,
+        },
       },
     });
   });
@@ -410,11 +420,15 @@ describe("Victim Identifier tests suite", () => {
     });
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(victims).toStrictEqual({
-      "0x0000000000000000000000000000000000001234": {
-        protocolUrl: "https://uniswap.org/",
-        protocolTwitter: "Uniswap",
-        tag: "Uniswap V3",
-        holders: ["0x000000000000000000000000000000000022aabb", "0x0000000000000000000000000000000033aabbcc"],
+      exploitationStage: {},
+      preparationStage: {
+        "0x0000000000000000000000000000000000001234": {
+          protocolUrl: "https://uniswap.org/",
+          protocolTwitter: "Uniswap",
+          tag: "Uniswap V3",
+          holders: ["0x000000000000000000000000000000000022aabb", "0x0000000000000000000000000000000033aabbcc"],
+          confidence: 0,
+        },
       },
     });
   });
@@ -490,11 +504,15 @@ describe("Victim Identifier tests suite", () => {
 
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(victims).toStrictEqual({
-      "0x0000000000000000000000000000000000001234": {
-        protocolUrl: "https://worldcupinu.app/",
-        protocolTwitter: "wcierc20",
-        tag: "World Cup Inu 2022",
-        holders: [],
+      exploitationStage: {},
+      preparationStage: {
+        "0x0000000000000000000000000000000000001234": {
+          protocolUrl: "https://worldcupinu.app/",
+          protocolTwitter: "wcierc20",
+          tag: "World Cup Inu 2022",
+          holders: [],
+          confidence: 0,
+        },
       },
     });
   });
@@ -568,11 +586,15 @@ describe("Victim Identifier tests suite", () => {
 
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(victims).toStrictEqual({
-      "0x0000000000000000000000000000000000001234": {
-        protocolUrl: "",
-        protocolTwitter: "",
-        tag: "DOGE",
-        holders: [],
+      exploitationStage: {},
+      preparationStage: {
+        "0x0000000000000000000000000000000000001234": {
+          protocolUrl: "",
+          protocolTwitter: "",
+          tag: "DOGE",
+          holders: [],
+          confidence: 0,
+        },
       },
     });
   });
@@ -662,11 +684,15 @@ describe("Victim Identifier tests suite", () => {
 
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(victims).toStrictEqual({
-      "0x0000000000000000000000000000000000001234": {
-        protocolUrl: "",
-        protocolTwitter: "",
-        tag: "VerifiedContract22",
-        holders: [],
+      exploitationStage: {},
+      preparationStage: {
+        "0x0000000000000000000000000000000000001234": {
+          protocolUrl: "",
+          protocolTwitter: "",
+          tag: "VerifiedContract22",
+          holders: [],
+          confidence: 0,
+        },
       },
     });
   });
@@ -714,7 +740,16 @@ describe("Victim Identifier tests suite", () => {
     });
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(victims).toStrictEqual({
-      "0x0000000000000000000000000000000000001234": { holders: [], protocolTwitter: "", protocolUrl: "", tag: "HEY" },
+      exploitationStage: {
+        "0x0000000000000000000000000000000000001234": {
+          holders: [],
+          protocolTwitter: "",
+          protocolUrl: "",
+          tag: "HEY",
+          confidence: 0.4,
+        },
+      },
+      preparationStage: {},
     });
   });
 
@@ -733,7 +768,7 @@ describe("Victim Identifier tests suite", () => {
 
     mockProvider.addCallTo(TEST_TOKEN, 5444123, TOKEN_IFACE, "totalSupply", {
       inputs: [],
-      outputs: [ethers.BigNumber.from("4424324324423423")], // over 10% of the total supply
+      outputs: [ethers.BigNumber.from("4424324324423423")], // over 5% of the total supply
     });
 
     mockProvider.addCallTo(TEST_TOKEN, 5444123, TOKEN_IFACE, "decimals", {
@@ -747,12 +782,16 @@ describe("Victim Identifier tests suite", () => {
     });
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(victims).toStrictEqual({
-      "0x0000000000000000000000000000000000001234": {
-        holders: [],
-        protocolTwitter: "",
-        protocolUrl: "",
-        tag: "LpToken",
+      exploitationStage: {
+        "0x0000000000000000000000000000000000001234": {
+          holders: [],
+          protocolTwitter: "",
+          protocolUrl: "",
+          tag: "LpToken",
+          confidence: 1,
+        },
       },
+      preparationStage: {},
     });
   });
 
@@ -799,7 +838,16 @@ describe("Victim Identifier tests suite", () => {
     });
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(victims).toStrictEqual({
-      "0x0000000000000000000000000000000000001234": { holders: [], protocolTwitter: "", protocolUrl: "", tag: "AWW" },
+      exploitationStage: {
+        "0x0000000000000000000000000000000000001234": {
+          holders: [],
+          protocolTwitter: "",
+          protocolUrl: "",
+          tag: "AWW",
+          confidence: 1,
+        },
+      },
+      preparationStage: {},
     });
   });
 
@@ -876,18 +924,23 @@ describe("Victim Identifier tests suite", () => {
     });
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
     expect(victims).toStrictEqual({
-      "0x0000000000000000000000000000000000001234": {
-        holders: [],
-        protocolTwitter: "",
-        protocolUrl: "",
-        tag: "ERC20LostERC20",
+      exploitationStage: {
+        "0x0000000000000000000000000000000000001234": {
+          holders: [],
+          protocolTwitter: "",
+          protocolUrl: "",
+          tag: "ERC20LostERC20",
+          confidence: 1,
+        },
+        "0x0000000000000000000000000000000000004444": {
+          holders: [],
+          protocolTwitter: "",
+          protocolUrl: "",
+          tag: "ERC20LostNative",
+          confidence: 1,
+        },
       },
-      "0x0000000000000000000000000000000000004444": {
-        holders: [],
-        protocolTwitter: "",
-        protocolUrl: "",
-        tag: "ERC20LostNative",
-      },
+      preparationStage: {},
     });
   });
 
@@ -896,6 +949,25 @@ describe("Victim Identifier tests suite", () => {
     const TRANSFER_TO = createAddress("0x5678");
     const createdContractAddress = createAddress("0x789");
     const extractedAddress = createAddress("0x11888");
+
+    mockAlertsResponse = {
+      alerts: [
+        {
+          metadata: {
+            address1: createAddress("0x1234"),
+            address1again: createAddress("0x1234"),
+            address2: createAddress("0x5678"),
+          },
+        },
+      ],
+      pageInfo: {
+        hasNextPage: false,
+        endCursor: {
+          alertId: "1234",
+          blockNumber: 0,
+        },
+      },
+    };
 
     const mockTxEvent: TestTransactionEventExtended = new TestTransactionEventExtended();
 
@@ -953,18 +1025,6 @@ describe("Victim Identifier tests suite", () => {
           )
         );
       } else if (callCount === 3) {
-        // Exploitation Stage Victim: Failed call to Luabase DB
-        return Promise.reject(new Response());
-      } else if (callCount === 4) {
-        // Exploitation Stage Victim: Failed call to get the contract creator address
-        return Promise.reject(new Response());
-      } else if (callCount === 5) {
-        // Exploitation Stage Victim: Failed call to Ethereum list DB
-        return Promise.reject(new Response());
-      } else if (callCount === 6) {
-        // Exploitation Stage Victim: Failed call to get the token holders
-        return Promise.reject(new Response());
-      } else if (callCount === 7) {
         // Preparation Stage Victim: Call to Luabase DB
         return Promise.resolve(
           new Response(
@@ -973,18 +1033,34 @@ describe("Victim Identifier tests suite", () => {
             })
           )
         );
-      } else if (callCount === 8) {
+      } else if (callCount === 4) {
         // Preparation Stage Victim: Call to the Ethplorer API
         return Promise.resolve(
           new Response(
             JSON.stringify({
               holders: [
                 { address: createAddress("0x22aabb"), balance: 133, share: 28 },
-                { address: createAddress("0x33aabbcc"), balance: 4233, share: 228 },
+                {
+                  address: createAddress("0x33aabbcc"),
+                  balance: 4233,
+                  share: 228,
+                },
               ],
             })
           )
         );
+      } else if (callCount === 5) {
+        // Exploitation Stage Victim: Failed call to Luabase DB
+        return Promise.reject(new Response());
+      } else if (callCount === 6) {
+        // Exploitation Stage Victim: Failed call to get the contract creator address
+        return Promise.reject(new Response());
+      } else if (callCount === 7) {
+        // Exploitation Stage Victim: Failed call to Ethereum list DB
+        return Promise.reject(new Response());
+      } else if (callCount === 8) {
+        // Exploitation Stage Victim: Failed call to get the token holders
+        return Promise.reject(new Response());
       }
     });
 
@@ -995,13 +1071,25 @@ describe("Victim Identifier tests suite", () => {
       outputs: ["AWW"],
     });
     const victims = await victimIdentifier.getIdentifiedVictims(mockTxEvent);
+
     expect(victims).toStrictEqual({
-      "0x0000000000000000000000000000000000001234": { holders: [], protocolTwitter: "", protocolUrl: "", tag: "AWW" },
-      "0x0000000000000000000000000000000000011888": {
-        holders: ["0x000000000000000000000000000000000022aabb", "0x0000000000000000000000000000000033aabbcc"],
-        protocolTwitter: "Victim5678Twitter",
-        protocolUrl: "victim5678.org",
-        tag: "Victim5678",
+      exploitationStage: {
+        "0x0000000000000000000000000000000000001234": {
+          holders: [],
+          protocolTwitter: "",
+          protocolUrl: "",
+          tag: "AWW",
+          confidence: 1,
+        },
+      },
+      preparationStage: {
+        "0x0000000000000000000000000000000000011888": {
+          holders: ["0x000000000000000000000000000000000022aabb", "0x0000000000000000000000000000000033aabbcc"],
+          protocolTwitter: "Victim5678Twitter",
+          protocolUrl: "victim5678.org",
+          tag: "Victim5678",
+          confidence: 1,
+        },
       },
     });
   });

--- a/src/utils/victim-identification/victim.identifier.ts
+++ b/src/utils/victim-identification/victim.identifier.ts
@@ -231,7 +231,12 @@ export default class VictimIdentifier extends TokenInfoFetcher {
                 const threshold = totalSupply.div(20); // 5%
                 const absValue = value![token].mul(-1);
                 if (absValue.gt(threshold)) {
-                  const percentage = absValue.mul(100).div(totalSupply).toNumber();
+                  let percentage: number;
+                  try {
+                    percentage = absValue.mul(100).div(totalSupply).toNumber();
+                  } catch {
+                    percentage = 100;
+                  }
                   const confidence = this.getExploitationStageConfidenceLevel(percentage, "totalSupply") as number;
                   victims.push({ address, confidence });
                 }

--- a/src/utils/victim-identification/victim.identifier.ts
+++ b/src/utils/victim-identification/victim.identifier.ts
@@ -274,7 +274,12 @@ export default class VictimIdentifier extends TokenInfoFetcher {
     return this.victimOccurences;
   };
 
-  private identifyVictims = async (victims: string[], chainId: number, blockNumber: number) => {
+  private identifyVictims = async (
+    provider: ethers.providers.JsonRpcProvider,
+    victims: string[],
+    chainId: number,
+    blockNumber: number
+  ) => {
     let identifiedVictims: Record<
       string,
       { protocolUrl: string; protocolTwitter: string; tag: string; holders: string[] }
@@ -319,7 +324,7 @@ export default class VictimIdentifier extends TokenInfoFetcher {
 
               // If the tag is "Not Found", try to fetch the contract name
               if (tag === "Not Found") {
-                tag = await getContractName(victim, chainId);
+                tag = await getContractName(provider, victim, chainId);
               }
             }
           }
@@ -383,7 +388,7 @@ export default class VictimIdentifier extends TokenInfoFetcher {
     const victimsToProcess = Array.from(
       new Set([...exploitationStageVictims, ...Object.keys(sortedPreparationStageVictims)])
     );
-    const victims = await this.identifyVictims(victimsToProcess, chainId, blockNumber);
+    const victims = await this.identifyVictims(this.provider, victimsToProcess, chainId, blockNumber);
 
     return victims;
   };

--- a/src/utils/victim-identification/victim.identifier.ts
+++ b/src/utils/victim-identification/victim.identifier.ts
@@ -24,7 +24,7 @@ export default class VictimIdentifier extends TokenInfoFetcher {
   addressesExtractor: AddressesExtractor;
   private init: boolean;
   private protocols: string[][];
-  private victimOccurences: Record<string, number>;
+  private victimOccurrences: Record<string, number>;
   private isContractCache: LRU<string, boolean>;
 
   constructor(provider: ethers.providers.JsonRpcProvider, apiKeys: apiKeys) {
@@ -60,7 +60,7 @@ export default class VictimIdentifier extends TokenInfoFetcher {
     this.init = false;
     this.protocols = [];
     this.getProtocols();
-    this.victimOccurences = {};
+    this.victimOccurrences = {};
     this.isContractCache = new LRU<string, boolean>({ max: 10000 });
   }
 
@@ -276,7 +276,7 @@ export default class VictimIdentifier extends TokenInfoFetcher {
             const values: string[] = Object.values(alert.metadata);
             const victimContracts: string[] = values.filter((value: string) => value.startsWith("0x"));
             victimContracts.forEach((victim: string) => {
-              this.victimOccurences[victim] = this.victimOccurences[victim] ? ++this.victimOccurences[victim] : 1;
+              this.victimOccurrences[victim] = this.victimOccurrences[victim] ? ++this.victimOccurrences[victim] : 1;
             });
           }
         });
@@ -292,7 +292,7 @@ export default class VictimIdentifier extends TokenInfoFetcher {
       }
     }
 
-    return this.victimOccurences;
+    return this.victimOccurrences;
   };
 
   private identifyVictims = async (
@@ -395,7 +395,7 @@ export default class VictimIdentifier extends TokenInfoFetcher {
   public getIdentifiedVictims = async (txEvent: TransactionEvent) => {
     const { network: chainId, blockNumber } = txEvent;
     if (blockNumber !== this.latestBlockNumber) {
-      this.victimOccurences = await this.getVictimOccurences(txEvent);
+      this.victimOccurrences = await this.getVictimOccurences(txEvent);
       this.latestBlockNumber = blockNumber;
     }
 
@@ -403,7 +403,7 @@ export default class VictimIdentifier extends TokenInfoFetcher {
     const extractedAddresses = await this.addressesExtractor.extractAddresses(txEvent);
     const sortedRecord: Record<string, number> = {};
     for (const victim of Array.from(extractedAddresses)) {
-      sortedRecord[victim] = this.victimOccurences.hasOwnProperty(victim) ? this.victimOccurences[victim] : 0;
+      sortedRecord[victim] = this.victimOccurrences.hasOwnProperty(victim) ? this.victimOccurrences[victim] : 0;
     }
     const sortedPreparationStageVictims: Record<string, number> = Object.fromEntries(
       Object.entries(sortedRecord).sort((a, b) => a[1] - b[1])

--- a/src/utils/victim-identification/victim.identifier.ts
+++ b/src/utils/victim-identification/victim.identifier.ts
@@ -225,12 +225,12 @@ export default class VictimIdentifier extends TokenInfoFetcher {
       this.init = true;
       blockNumberRange = {
         startBlockNumber: 0,
-        endBlockNumber: blockNumber,
+        endBlockNumber: blockNumber - 1,
       };
     } else {
       blockNumberRange = {
-        startBlockNumber: blockNumber,
-        endBlockNumber: blockNumber,
+        startBlockNumber: blockNumber - 1,
+        endBlockNumber: blockNumber - 1,
       };
     }
 
@@ -245,7 +245,7 @@ export default class VictimIdentifier extends TokenInfoFetcher {
           botIds: PREPARATION_BOT,
           chainId: chainId,
           blockNumberRange: blockNumberRange,
-          first: 6000,
+          first: 4000,
           startingCursor: startingCursor,
         });
 

--- a/src/utils/victim-identification/victim.identifier.ts
+++ b/src/utils/victim-identification/victim.identifier.ts
@@ -9,6 +9,7 @@ import {
   wrappedNativeTokens,
   WRAPPED_NATIVE_TOKEN_EVENTS,
   ZERO,
+  MAX_USD_VALUE,
 } from "./helpers/constants";
 import TokenInfoFetcher from "./helpers/token.info.fetcher";
 import {
@@ -293,6 +294,16 @@ export default class VictimIdentifier extends TokenInfoFetcher {
         }
       }
     }
+
+    let maxOccurrences = 0;
+
+    for (const victim in this.victimOccurrences) {
+      if (this.victimOccurrences[victim] > maxOccurrences) {
+        maxOccurrences = this.victimOccurrences[victim];
+      }
+    }
+
+    this.maxOccurrences = maxOccurrences;
 
     return this.victimOccurrences;
   };

--- a/src/utils/victim-identification/victim.identifier.ts
+++ b/src/utils/victim-identification/victim.identifier.ts
@@ -329,26 +329,32 @@ export default class VictimIdentifier extends TokenInfoFetcher {
             }
           }
         }
-        // Skip the victim if the tag is empty or if it is a known false positive
+        // Skip the victim if it is a known false positive
         if (
-          tag === "Not Found" ||
-          tag === "" || // 0x227ad7bdeaefa4f23da290d19f17705949b65923e334b66288de5d6329e599c3
           tag.startsWith("MEV") ||
           tag.startsWith("Null") ||
           tag.startsWith("Fund") || // 0xa294cca691e4c83b1fc0c8d63d9a3eef0a196de1
-          tag.split(" ").includes("Hack") || // 0x1b4d1e3318b1bffca9562b7aca468009d971d59848b6c0672dd1600d481693b6
           tag.split(" ").includes("Exploiter")
         ) {
           return;
         }
-        let [protocolUrl, protocolTwitter] = urlAndTwitterFetcher(this.protocols, tag);
-        if (protocolUrl === "" && protocolTwitter === "") {
-          [protocolUrl, protocolTwitter] = urlAndTwitterFetcher(
-            this.protocols,
-            await this.getName(blockNumber, victim.toLowerCase())
-          );
+
+        let protocolUrl = "";
+        let protocolTwitter = "";
+        let holders: string[] = [];
+
+        if (tag !== "Not Found" && tag !== "") {
+          [protocolUrl, protocolTwitter] = urlAndTwitterFetcher(this.protocols, tag);
+          if (protocolUrl === "" && protocolTwitter === "") {
+            [protocolUrl, protocolTwitter] = urlAndTwitterFetcher(
+              this.protocols,
+              await this.getName(blockNumber, victim.toLowerCase())
+            );
+          }
+          holders = await this.getHolders(victim, tag);
+        } else if (tag === "Not Found") {
+          tag = "";
         }
-        const holders = await this.getHolders(victim, tag);
 
         return {
           protocolUrl,


### PR DESCRIPTION
Changes:

- Add check of implementation contract name
- Modify `getAlerts` to fetch fewer alert in each call + in each block fetch the alerts of the previous 
- Remove skipping the victim if the tag had not been found
- Check percentage of `totalSupply` when USD value can't be fetched