### PR TITLE
Update MockEthersProvider With getTransaction and getTransactionReceipt from ethersjs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ mockTransactionData.setValue(ethers.utils.parseEther("1.0"))
 .setGasPrice(ethers.BigNumber.from(1000000))
 .setGasLimit(ethers.BigNumber.from(21000))
 
-mockTransaction.setHas("0x1234567890987654345678987654...");
+mockTransactionData.setHash("0x1234567890987654345678987654...");
 // or can generate the hash based on the current transaction config
 mockTransaction.generateHash();
 

--- a/README.md
+++ b/README.md
@@ -468,9 +468,9 @@ You can get only the `TransactionResponse` or `TransactionReceipt` by the callin
 ```ts
 ...
 
-const txResponse: ethers.providers.TransactionResponse = mockTransactionData.getTransactionResponse();
+const txResponse: providers.TransactionResponse = mockTransactionData.getTransactionResponse();
 
-const txReceipt: ethers.providers.TransactionReceipt = mockTransactionData.getTransactionReceipt();
+const txReceipt: providers.TransactionReceipt = mockTransactionData.getTransactionReceipt();
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -449,11 +449,50 @@ mockTransactionData.setHash("0x1234567890987654345678987654...");
 // or can generate the hash based on the current transaction config
 mockTransactionData.generateHash();
 
-const transactionResponse: Partial<ethers.providers.TransactionResponse> = {}  // Add the fields that you want to set for the TransactionResponse.
+const transactionResponse: Partial<providers.TransactionResponse> = {   // Add the fields that you want to set for the TransactionResponse.
+  hash: '0x3fda39a81c47dc37d84c761c3cbbea375866c1fbdfcf91566eaa4c4ef62c70ad',
+  type: 2,
+  accessList: [],
+  blockHash: '0x25e44bfb2c3a47703c86884110a6d5c5a7a655b02fe1ca3a9d135e7459efab95',
+  blockNumber: 18095175,
+  transactionIndex: 109,
+  confirmations: 22,
+  from: '0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5',
+  gasPrice: BigNumber.from("9999762606"),
+  maxPriorityFeePerGas: BigNumber.from("0"),
+  maxFeePerGas: BigNumber.from("9999762606"),
+  gasLimit: BigNumber.from(0x5208),
+  to: '0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263',
+  value: BigNumber.from("63002772804144528"),
+  nonce: 436110,
+  data: '0x',
+  r: '0xa62a979dd4713a8c12de05167f68ddbfab947886d44eb0806f9b4f8c0b7d4ca5',
+  s: '0x72058708dfe24365969eff435447a92cd9ee0348e898b5ea1d26211f77241a6d',
+  v: 1,
+  creates: null,
+  chainId: 1
+}
 
 mockTransaction.setTransactionResponse(transactionResponse)  // if hash is not set, the hash will be generated.
 
-const transactionReceipt: Partial<ethers.providers.TransactionReceipt> = {}  // Add the fields that you want to set for the TransactionReceipt.
+const transactionReceipt: Partial<providers.TransactionReceipt> = { // Add the fields that you want to set for the TransactionReceipt.
+  to: '0x4675C7e5BaAFBFFbca748158bEcBA61ef3b0a263',
+  from: '0xDAFEA492D9c6733ae3d56b7Ed1ADB60692c98Bc5',
+  contractAddress: null,
+  transactionIndex: 109,
+  gasUsed: BigNumber.from(21000),
+  logsBloom: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+  blockHash: '0x25e44bfb2c3a47703c86884110a6d5c5a7a655b02fe1ca3a9d135e7459efab95',
+  transactionHash: '0x3fda39a81c47dc37d84c761c3cbbea375866c1fbdfcf91566eaa4c4ef62c70ad',
+  logs: [],
+  blockNumber: 18095175,
+  confirmations: 33,
+  cumulativeGasUsed: BigNumber.from(12276572),
+  effectiveGasPrice: BigNumber.from("9999762606"),
+  status: 1,
+  type: 2,
+  byzantium: true
+}
 
 mockTransaction.setTransactionReceipt(transactionReceipt) // if hash is not set, the hash will be generated.
 
@@ -482,8 +521,10 @@ Some of the methods that the MockTransactionData provides to set the transaction
 - `setFrom(address: string)`: Sets the from Address
 - `setTo(address: string)`: Sets the to Address
 - `setNonce(value: number)`: Sets the Nonce.
+- `setContractAddress(address: string)`: Sets the contract Address field of the transaction.
 - `setGasPrice(value: string)`: Sets the Gas price for the `MockTransactionData`
 - `setGasLimit(value: string)`: Sets the gas limit for the `MockTransactionData`
+- `setData(data: string)`: Sets the data of the transaction.
 - `setLogs(logs: ethers.providers.Log[])`: Sets the logs field in the transaction receipt field of the `MockTransactionData`
 - `setLogsBloom(value: string)`: Sets the logsBloom value.
 - `setTimestamp(timestamp: number)`: Sets the timestamp of the transaction.
@@ -493,6 +534,14 @@ Some of the methods that the MockTransactionData provides to set the transaction
 - `setTransactionReceipt(receipt: Partial<ethers.providers.TransactionReceipt>)`: Sets all the values for the ethers `TransactionReceipt` based on the given optional/partial fields. Generates the transaction hash if not given.
 - `setBlockHash(hash: string)`: Sets the Block hash.
 - `setBlockNumber(blockNumber: number)`: Sets the block number.
+- `setMaxPriorityFeePerGas(value: string)`: Sets the Max Priority fee for the transaction.
+- `setMaxFeePerGas(value: string)`: Sets the Max Fee field of the transaction.
+- `setTransactionType(type: number)`: Sets the value of type in the transaction. The type refers to the "Typed-Transaction features".
+- `setTransactionIndex(index: number)`: Sets the "transactionIndex" field in the transaction.
+- `setChainId(chainId: number)`: Sets the chainId of the transaction.
+- `setGasUsed(value: string)`: Sets the gasUsed field in the transaction.
+- `setCumulativeGasUsed(value: string)`: Sets the cumulativeGasUsed field in the transaction.
+- `setEffectiveGasPrice(value: string)`: Sets the effectiveGasPrice field in the transaction.
 
 ### MockEthersProvider
 
@@ -534,9 +583,7 @@ This mock provides some methods to set up the values that the provider should re
 - `addSigner(addr)`. This function prepares a valid signer for the given address that uses the provider being used.
 - `addLogs(logs)`. This method allows you to add entries to the logs record that will be filtered in `getLogs` if the filter specified wasn't yet added in `addFilteredLogs`.
 - `setNetwork(chainId, ensAddress?, name?)`. This method allows you to set up the network information (`chainId`, `ensAddress` and `name`) that will be returned when there's a call to `getNetwork`.
-- `setTransactionResponse(transaction: MockTransactionData)`: This method accepts the transaction parameter of type `MockTransactionData` and allows you to set up the return value for `ethers.providers.getTransaction(hash: string)`.
-- `setTransactionReceipt(transaction: MockTransactionData)`: This method accepts the transaction parameter of type `MockTransactionData` and allows you to set up the return value for `ethers.providers.getTransactionReceipt(hash: string)`.
-- `setTransaction(transaction: MockTransactionData)`: This method allows you to set the return value for both `ethers.providers.getTransaction(hash: string)` and `ethers.providers.getTransactionReceipt(hash: string)`
+- `setTransaction(transaction: MockTransactionData)`: This method accepts the transaction parameter of type `MockTransactionData` and allows you to set the return value for both `ethers.providers.getTransaction(hash: string)` and `ethers.providers.getTransactionReceipt(hash: string)`
 - `clear()`. This function clears all the mocked data.
 
 All the data you set in the provider will be used until the `clear` function is called.

--- a/README.md
+++ b/README.md
@@ -427,6 +427,71 @@ Parameters description:
 - `block`: It is the `BlockEvent` that the bot will handle.
 - `tx#`: These are the `TransactionEvent` objects asociated with the `BlockEvent` that the bot will handle.
 
+### MockTransactionData
+
+This is a helper class for mocking the interfaces `ethers.providers.TransactionResponse` and `ethers.providers.TransactionReceipt` by implementing them.
+Since this class implements both of these interfaces, the instance of this class can be used for ethers `TransactionResponse` and `TransactionReceipt`.
+
+The class is instansiated with default values for all the fields and has set functions to set the values for each of these fields.
+
+Basic Usage:
+
+```ts
+import { MockTransactionData } from "forta-agent-tools/lib/test";
+import { ethers } from "forta-agent-tools"
+
+const mockTransactionData: MockTransactionData = new MockTransactionData();
+mockTransactionData.setValue(ethers.utils.parseEther("1.0")).setGasPrice(ethers.BigNumber.from(1000000)).setGasLimit(ethers.BigNumber.from(21000))
+
+mockTransaction.setHas("0x1234567890987654345678987654...");
+// or can generate the hash based on the current transaction config
+mockTransaction.generateHash();
+
+const transactionResponse: Partial<ethers.providers.TransactionResponse> = {}  // Add the fields that you want to set for the TransactionResponse.
+
+mockTransaction.setTransactionResponse(transactionResponse)  // if hash is not set, the hash will be generated.
+
+const transactionReceipt: Partial<ethers.providers.TransactionReceipt> = {}  // Add the fields that you want to set for the TransactionReceipt.
+
+mockTransaction.setTransactionReceipt(transactionReceipt) // if hash is not set, the hash will be generated.
+
+...
+
+```
+
+In this way the class can be used to shape the `MockTransactionData` into `ethers.providers.TransactionResponse` or/and `ethers.providers.TransactionReceipt`.
+
+You can get only the `TransactionResponse` or `TransactionReceipt` by the calling the methods.
+
+```ts
+...
+
+const txResponse: ethers.providers.TransactionResponse = mockTransactionData.getTransactionResponse();
+
+const txReceipt: ethers.providers.TransactionReceipt = mockTransactionData.getTransactionReceipt();
+
+```
+
+All of the set methods in the `MockTransactionData` will return the type `MockTransactionData`. So these set methods can be chained.
+Some of the methods that the MockTransactionData provides to set the transaction field values:
+
+- `setHash(hash: string)`: The method accepts a string and sets it as the txn hash for the `MockTransactionData`.
+- `generateHash()`: The method generates the txn hash based on the current `MockTransactionData` config and sets it as the txn hash.
+- `setFrom(address: string)`: Sets the from Address
+- `setTo(address: string)`: Sets the to Address
+- `setNonce(value: number)`: Sets the Nonce.
+- `setGasPrice(value: string)`: Sets the Gas price for the `MockTransactionData`
+- `setGasLimit(value: string)`: Sets the gas limit for the `MockTransactionData`
+- `setLogs(logs: ethers.providers.Log[])`: Sets the logs field in the transaction receipt field of the `MockTransactionData`
+- `setLogsBloom(value: string)`: Sets the logsBloom value.
+- `setTimestamp(timestamp: number)`: Sets the timestamp of the transaction.
+- `setStatus`: Sets the Transaction Status.
+- `setConfirmations(confirmations: number)`: Sets the number of confirmations for the transaction.
+- `setTransactionResponse(transaction: Partial<ethers.providers.TransactionResponse>)`: Sets all the values for the ethers `TransactionResponse` based on the given optional/partial fields. Generates the transaction hash if not given.
+- `setTransactionReceipt(receipt: Partial<ethers.providers.TransactionReceipt>)`: Sets all the values for the ethers `TransactionReceipt` based on the given optional/partial fields. Generates the transaction hash if not given.
+- `setBlockHash(hash: string)`: Sets the Block hash.
+- `setBlockNumber(blockNumber: number)`: Sets the block number.
+
 ### MockEthersProvider
 
 This is a helper class for mocking the `ethers.providers.Provider` class.
@@ -467,6 +532,9 @@ This mock provides some methods to set up the values that the provider should re
 - `addSigner(addr)`. This function prepares a valid signer for the given address that uses the provider being used.
 - `addLogs(logs)`. This method allows you to add entries to the logs record that will be filtered in `getLogs` if the filter specified wasn't yet added in `addFilteredLogs`.
 - `setNetwork(chainId, ensAddress?, name?)`. This method allows you to set up the network information (`chainId`, `ensAddress` and `name`) that will be returned when there's a call to `getNetwork`.
+- `setTransactionResponse(transaction: MockTransactionData)`: This method accepts the transaction parameter of type `MockTransactionData` and allows you to set up the return value for `ethers.providers.getTransaction(hash: string)`.
+- `setTransactionReceipt(transaction: MockTransactionData)`: This method accepts the transaction parameter of type `MockTransactionData` and allows you to set up the return value for `ethers.providers.getTransactionReceipt(hash: string)`.
+- `setTransaction(transaction: MockTransactionData)`: This method allows you to set the return value for both `ethers.providers.getTransaction(hash: string)` and `ethers.providers.getTransactionReceipt(hash: string)`
 - `clear()`. This function clears all the mocked data.
 
 All the data you set in the provider will be used until the `clear` function is called.

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Basic Usage:
 
 ```ts
 import { MockTransactionData } from "forta-agent-tools/lib/test";
-import { ethers } from "forta-agent-tools"
+import { utils, BigNumber, providers } from "ethers";
 
 const mockTransactionData: MockTransactionData = new MockTransactionData();
 mockTransactionData.setValue(ethers.utils.parseEther("1.0"))

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ mockTransactionData.setValue(ethers.utils.parseEther("1.0"))
 
 mockTransactionData.setHash("0x1234567890987654345678987654...");
 // or can generate the hash based on the current transaction config
-mockTransaction.generateHash();
+mockTransactionData.generateHash();
 
 const transactionResponse: Partial<ethers.providers.TransactionResponse> = {}  // Add the fields that you want to set for the TransactionResponse.
 

--- a/README.md
+++ b/README.md
@@ -441,7 +441,9 @@ import { MockTransactionData } from "forta-agent-tools/lib/test";
 import { ethers } from "forta-agent-tools"
 
 const mockTransactionData: MockTransactionData = new MockTransactionData();
-mockTransactionData.setValue(ethers.utils.parseEther("1.0")).setGasPrice(ethers.BigNumber.from(1000000)).setGasLimit(ethers.BigNumber.from(21000))
+mockTransactionData.setValue(ethers.utils.parseEther("1.0"))
+.setGasPrice(ethers.BigNumber.from(1000000))
+.setGasLimit(ethers.BigNumber.from(21000))
 
 mockTransaction.setHas("0x1234567890987654345678987654...");
 // or can generate the hash based on the current transaction config
@@ -461,7 +463,7 @@ mockTransaction.setTransactionReceipt(transactionReceipt) // if hash is not set,
 
 In this way the class can be used to shape the `MockTransactionData` into `ethers.providers.TransactionResponse` or/and `ethers.providers.TransactionReceipt`.
 
-You can get only the `TransactionResponse` or `TransactionReceipt` by the calling the methods.
+You can get only the `TransactionResponse` or `TransactionReceipt` by the calling the methods:
 
 ```ts
 ...

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Parameters description:
 This is a helper class for mocking the interfaces `ethers.providers.TransactionResponse` and `ethers.providers.TransactionReceipt` by implementing them.
 Since this class implements both of these interfaces, the instance of this class can be used for ethers `TransactionResponse` and `TransactionReceipt`.
 
-The class is instansiated with default values for all the fields and has set functions to set the values for each of these fields.
+The class is instantiated with default values for all the fields and has set functions to set the values for each of these fields.
 
 Basic Usage:
 

--- a/README.md
+++ b/README.md
@@ -441,9 +441,9 @@ import { MockTransactionData } from "forta-agent-tools/lib/test";
 import { utils, BigNumber, providers } from "ethers";
 
 const mockTransactionData: MockTransactionData = new MockTransactionData();
-mockTransactionData.setValue(ethers.utils.parseEther("1.0"))
-.setGasPrice(ethers.BigNumber.from(1000000))
-.setGasLimit(ethers.BigNumber.from(21000))
+mockTransactionData.setValue(utils.parseEther("1.0"))
+.setGasPrice(BigNumber.from(1000000))
+.setGasLimit(BigNumber.from(21000))
 
 mockTransactionData.setHash("0x1234567890987654345678987654...");
 // or can generate the hash based on the current transaction config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forta-agent-tools",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "forta-agent-tools",
-      "version": "3.2.8",
+      "version": "3.2.9",
       "license": "GPL-3.0",
       "dependencies": {
         "@ethersproject/properties": "^5.6.0",
@@ -4877,9 +4877,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -5878,9 +5878,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9606,9 +9606,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -10332,9 +10332,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forta-agent-tools",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "Forta Agents for common approaches",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -2,6 +2,7 @@ import { TestTransactionEvent } from "./test_transaction_event";
 import { TestBlockEvent } from "./test_block_event";
 import MockEthersProvider from "./mock_ethers_provider";
 import MockEthersSigner from "./mock_ethers_signer";
+import { MockTransactionData } from "./mock_transaction_data";
 
 import {
   Finding,
@@ -37,4 +38,4 @@ export const generalTestFindingGenerator = (..._: any[]): Finding => {
   });
 };
 
-export { TestTransactionEvent, TestBlockEvent, MockEthersProvider, MockEthersSigner };
+export { TestTransactionEvent, TestBlockEvent, MockEthersProvider, MockEthersSigner, MockTransactionData };

--- a/src/test/mock_ethers_provider.spec.ts
+++ b/src/test/mock_ethers_provider.spec.ts
@@ -2,6 +2,7 @@ import { utils, Contract } from "ethers";
 import { ethers, keccak256 } from "forta-agent";
 import { createAddress } from "../utils";
 import MockEthersProvider from "./mock_ethers_provider";
+import MockTransactionData from "./mock_transaction_data";
 
 const EVENT_1_SIGHASH: string = keccak256("Event1()");
 const EVENT_2_SIGHASH: string = keccak256("Event2()");
@@ -215,5 +216,129 @@ describe("MockEthersProvider tests suite", () => {
       // check the value previously set
       expect(mockProvider.getSigner(addr).sendTransaction()).toStrictEqual(`old-call-from-${addr}`);
     }
+  });
+
+  it("should return the mocked transaction response", async () => {
+    const mockTransactionData: MockTransactionData = new MockTransactionData();
+
+    const txParams: Partial<ethers.providers.TransactionResponse> = {
+      nonce: 1,
+      gasLimit: ethers.BigNumber.from(21000),
+      gasPrice: ethers.BigNumber.from(1000000000),
+      to: createAddress("0x67"),
+      value: ethers.utils.parseEther("1"),
+      data: "0x",
+      chainId: 1,
+      from: createAddress("0x87"),
+      timestamp: Date.now(),
+      blockHash: ethers.utils.keccak256("0x1234"),
+      blockNumber: 1337,
+      confirmations: 1,
+      maxFeePerGas: ethers.BigNumber.from(1000000000),
+      maxPriorityFeePerGas: ethers.BigNumber.from(1000000000),
+      r: "0x",
+      s: "0x",
+      v: 0,
+      raw: "0x",
+      type: 1,
+    };
+
+    mockTransactionData.setTransactionResponse(txParams);
+
+    mockProvider.setTransactionResponse(mockTransactionData);
+
+    const transactionResponse: ethers.providers.TransactionResponse = await mockProvider.getTransaction(
+      mockTransactionData.hash
+    );
+    expect(transactionResponse).toStrictEqual(mockTransactionData.getTransactionResponse());
+
+    mockTransactionData.setHash(ethers.utils.hexlify(ethers.utils.randomBytes(32)));
+
+    mockProvider.setTransaction(mockTransactionData);
+
+    const txResponse: ethers.providers.TransactionResponse = await mockProvider.getTransaction(
+      mockTransactionData.hash
+    );
+    expect(txResponse).toStrictEqual(mockTransactionData.getTransactionResponse());
+  });
+
+  it("should return the mocked transaction receipt", async () => {
+    const mockTransactionData: MockTransactionData = new MockTransactionData();
+
+    const txReceiptParams: Partial<ethers.providers.TransactionReceipt> = {
+      to: createAddress("0x67"),
+      from: createAddress("0x87"),
+      contractAddress: createAddress("0x87"),
+      transactionIndex: 0,
+      gasUsed: ethers.BigNumber.from(21000),
+      logsBloom: "0x",
+      blockHash: ethers.utils.keccak256("0x1234"),
+      blockNumber: 1337,
+      confirmations: 1,
+      cumulativeGasUsed: ethers.BigNumber.from(21000),
+      byzantium: true,
+      logs: [],
+      status: 1,
+      type: 1,
+      effectiveGasPrice: ethers.BigNumber.from(1000000000),
+      root: "0x",
+    };
+
+    mockTransactionData.setTransactionReceipt(txReceiptParams);
+
+    mockProvider.setTransactionReceipt(mockTransactionData);
+
+    const transactionReceipt: ethers.providers.TransactionReceipt = await mockProvider.getTransactionReceipt(
+      mockTransactionData.hash
+    );
+    expect(transactionReceipt).toStrictEqual(mockTransactionData.getTransactionReceipt());
+
+    mockTransactionData.setHash(ethers.utils.hexlify(ethers.utils.randomBytes(32)));
+
+    mockProvider.setTransaction(mockTransactionData);
+
+    const txReceipt: ethers.providers.TransactionReceipt = await mockProvider.getTransactionReceipt(
+      mockTransactionData.hash
+    );
+    expect(txReceipt).toStrictEqual(mockTransactionData.getTransactionReceipt());
+  });
+
+  it("should return the mocked transaction data when set transaction is used", async () => {
+    const mockTransactionData: MockTransactionData = new MockTransactionData();
+
+    const txParams: Partial<ethers.providers.TransactionResponse> | Partial<ethers.providers.TransactionReceipt> = {
+      nonce: 0,
+      gasLimit: ethers.BigNumber.from(21000),
+      gasPrice: ethers.BigNumber.from(1000000000),
+      to: createAddress("0x67"),
+      value: ethers.BigNumber.from(1000000000),
+      data: "0x",
+      chainId: 1,
+      from: createAddress("0x87"),
+      timestamp: Date.now(),
+      blockHash: ethers.utils.keccak256("0x1234"),
+      blockNumber: 1337,
+      confirmations: 1,
+      maxFeePerGas: ethers.BigNumber.from(1000000000),
+      logsBloom: "0x",
+      logs: [],
+      cumulativeGasUsed: ethers.BigNumber.from(21000),
+      type: 1,
+    };
+
+    mockTransactionData.setTransactionResponse(txParams);
+    mockTransactionData.setTransactionReceipt(txParams as Partial<ethers.providers.TransactionReceipt>);
+
+    mockProvider.setTransaction(mockTransactionData);
+
+    const transactionResponse: ethers.providers.TransactionResponse = await mockProvider.getTransaction(
+      mockTransactionData.hash
+    );
+    const transactionReceipt: ethers.providers.TransactionReceipt = await mockProvider.getTransactionReceipt(
+      mockTransactionData.hash
+    );
+
+    expect(transactionResponse).toStrictEqual(mockTransactionData.getTransactionResponse());
+    expect(transactionReceipt).toStrictEqual(mockTransactionData.getTransactionReceipt());
   });
 });

--- a/src/test/mock_ethers_provider.spec.ts
+++ b/src/test/mock_ethers_provider.spec.ts
@@ -245,7 +245,7 @@ describe("MockEthersProvider tests suite", () => {
 
     mockTransactionData.setTransactionResponse(txParams);
 
-    mockProvider.setTransactionResponse(mockTransactionData);
+    mockProvider.setTransaction(mockTransactionData);
 
     const transactionResponse: ethers.providers.TransactionResponse = await mockProvider.getTransaction(
       mockTransactionData.hash
@@ -286,7 +286,7 @@ describe("MockEthersProvider tests suite", () => {
 
     mockTransactionData.setTransactionReceipt(txReceiptParams);
 
-    mockProvider.setTransactionReceipt(mockTransactionData);
+    mockProvider.setTransaction(mockTransactionData);
 
     const transactionReceipt: ethers.providers.TransactionReceipt = await mockProvider.getTransactionReceipt(
       mockTransactionData.hash

--- a/src/test/mock_ethers_provider.ts
+++ b/src/test/mock_ethers_provider.ts
@@ -172,13 +172,13 @@ export default class MockEthersProvider {
     this.setTransactionReceipt(transaction);
   }
 
-  public setTransactionResponse(transaction: MockTransactionData) {
+  private setTransactionResponse(transaction: MockTransactionData) {
     when(this.getTransaction)
       .calledWith(transaction.hash)
       .mockReturnValue(Promise.resolve(transaction.getTransactionResponse()));
   }
 
-  public setTransactionReceipt(transaction: MockTransactionData) {
+  private setTransactionReceipt(transaction: MockTransactionData) {
     when(this.getTransactionReceipt)
       .calledWith(transaction.transactionHash)
       .mockReturnValue(Promise.resolve(transaction.getTransactionReceipt()));

--- a/src/test/mock_ethers_provider.ts
+++ b/src/test/mock_ethers_provider.ts
@@ -4,6 +4,7 @@ import { Log, Filter, FilterByBlockHash } from "@ethersproject/abstract-provider
 import { ethers } from "forta-agent";
 import MockEthersSigner from "./mock_ethers_signer";
 import { createAddress, toChecksumAddress } from "../utils";
+import MockTransactionData from "./mock_transaction_data";
 
 interface CallParams {
   inputs: any[];
@@ -18,6 +19,8 @@ export default class MockEthersProvider {
   public getStorageAt: any;
   public getBlockNumber: any;
   public getNetwork: any;
+  public getTransaction: any;
+  public getTransactionReceipt: any;
   public readonly _isProvider: boolean;
 
   private logs: Array<ethers.providers.Log>;
@@ -31,6 +34,10 @@ export default class MockEthersProvider {
     this.getStorageAt = jest.fn().mockImplementation(this.unconfiguredAsyncMockImplementation("getStorageAt"));
     this.getBlockNumber = jest.fn().mockImplementation(this.unconfiguredAsyncMockImplementation("getBlockNumber"));
     this.getNetwork = jest.fn().mockImplementation(this.unconfiguredAsyncMockImplementation("getNetwork"));
+    this.getTransaction = jest.fn().mockImplementation(this.unconfiguredAsyncMockImplementation("getTransaction"));
+    this.getTransactionReceipt = jest
+      .fn()
+      .mockImplementation(this.unconfiguredAsyncMockImplementation("getTransactionReceipt"));
 
     this.logs = [];
   }
@@ -158,6 +165,23 @@ export default class MockEthersProvider {
 
   public setNetwork(chainId: number, ensAddress: string = createAddress("0x0"), name: string = "") {
     when(this.getNetwork).calledWith().mockReturnValue({ chainId, ensAddress, name });
+  }
+
+  public setTransaction(transaction: MockTransactionData) {
+    this.setTransactionResponse(transaction);
+    this.setTransactionReceipt(transaction);
+  }
+
+  public setTransactionResponse(transaction: MockTransactionData) {
+    when(this.getTransaction)
+      .calledWith(transaction.hash)
+      .mockReturnValue(Promise.resolve(transaction.getTransactionResponse()));
+  }
+
+  public setTransactionReceipt(transaction: MockTransactionData) {
+    when(this.getTransactionReceipt)
+      .calledWith(transaction.transactionHash)
+      .mockReturnValue(Promise.resolve(transaction.getTransactionReceipt()));
   }
 
   public clear(): void {

--- a/src/test/mock_transaction_data.spec.ts
+++ b/src/test/mock_transaction_data.spec.ts
@@ -1,0 +1,131 @@
+import { BigNumber, ethers } from "ethers";
+import { MockTransactionData } from "./mock_transaction_data";
+import { createAddress } from "../utils";
+
+describe("Mock Transaction Data Test Suite", () => {
+  let mockTransactionData: MockTransactionData;
+
+  beforeEach(() => {
+    mockTransactionData = new MockTransactionData();
+  });
+
+  it("sets the given Hash", () => {
+    const hash = ethers.utils.keccak256("0x1234");
+    mockTransactionData.setHash(hash);
+    expect(mockTransactionData.hash).toEqual(hash);
+    expect(mockTransactionData.transactionHash).toEqual(hash);
+  });
+
+  it("generates the same hash for the same txParams", () => {
+    const txParams = {
+      nonce: 1,
+      gasLimit: BigNumber.from(21000),
+      gasPrice: BigNumber.from(1000000000),
+      to: createAddress("0x67"),
+      value: BigNumber.from(1000000000),
+      data: "0x",
+      chainId: 0,
+      from: createAddress("0x87"),
+    };
+
+    const hash1 = mockTransactionData.setTransactionResponse(txParams).hash;
+    const hash2 = mockTransactionData.setTransactionReceipt(txParams).hash;
+    const hash3 = mockTransactionData.generateHash().hash;
+
+    expect(hash1).toEqual(hash2);
+    expect(hash2).toEqual(hash3);
+  });
+
+  it("sets the given from address", () => {
+    const from = createAddress("0x1234");
+    mockTransactionData.setFrom(from);
+    expect(mockTransactionData.from).toEqual(from);
+  });
+
+  it("sets the given to address", () => {
+    const to = createAddress("0x1234");
+    mockTransactionData.setTo(to);
+    expect(mockTransactionData.to).toEqual(to);
+  });
+
+  it("returns an Object compatible with ethers TransactionResponse", () => {
+    const txParams = {
+      nonce: 1,
+      gasLimit: BigNumber.from(21000),
+      gasPrice: BigNumber.from(1000000000),
+      to: createAddress("0x67"),
+      value: BigNumber.from(1000000000),
+      data: "0x",
+      chainId: 1,
+      from: createAddress("0x87"),
+      timestamp: Date.now(),
+    };
+
+    const response: ethers.providers.TransactionResponse = mockTransactionData
+      .setTransactionResponse(txParams)
+      .getTransactionResponse();
+
+    expect(response).toEqual({
+      hash: mockTransactionData.hash,
+      blockHash: mockTransactionData.blockHash,
+      blockNumber: mockTransactionData.blockNumber,
+      timestamp: txParams.timestamp,
+      confirmations: 0,
+      from: txParams.from,
+      to: txParams.to,
+      data: txParams.data,
+      gasLimit: txParams.gasLimit,
+      gasPrice: txParams.gasPrice,
+      value: txParams.value,
+      nonce: txParams.nonce,
+      chainId: txParams.chainId,
+      type: 1,
+      wait: expect.any(Function),
+      accessList: undefined,
+      maxFeePerGas: undefined,
+      maxPriorityFeePerGas: undefined,
+      r: undefined,
+      s: undefined,
+      v: undefined,
+      raw: undefined,
+    });
+  });
+
+  it("returns an Object compatible with ethers TransactionReceipt", () => {
+    const txParams = {
+      nonce: 1,
+      gasLimit: BigNumber.from(21000),
+      gasPrice: BigNumber.from(1000000000),
+      to: createAddress("0x67"),
+      value: BigNumber.from(1000000000),
+      data: "0x",
+      chainId: 1,
+      from: createAddress("0x87"),
+      timestamp: Date.now(),
+    };
+
+    const receipt: ethers.providers.TransactionReceipt = mockTransactionData
+      .setTransactionReceipt(txParams)
+      .getTransactionReceipt();
+
+    expect(receipt).toEqual({
+      blockHash: mockTransactionData.blockHash,
+      blockNumber: mockTransactionData.blockNumber,
+      byzantium: false,
+      confirmations: 0,
+      contractAddress: mockTransactionData.contractAddress,
+      cumulativeGasUsed: mockTransactionData.cumulativeGasUsed,
+      effectiveGasPrice: mockTransactionData.effectiveGasPrice,
+      from: txParams.from,
+      gasUsed: mockTransactionData.gasUsed,
+      logs: mockTransactionData.logs,
+      logsBloom: mockTransactionData.logsBloom,
+      root: mockTransactionData.root,
+      status: mockTransactionData.status,
+      to: txParams.to,
+      transactionHash: mockTransactionData.transactionHash,
+      transactionIndex: mockTransactionData.transactionIndex,
+      type: 1,
+    });
+  });
+});

--- a/src/test/mock_transaction_data.ts
+++ b/src/test/mock_transaction_data.ts
@@ -1,0 +1,361 @@
+import { ethers } from "forta-agent";
+import { createAddress, createTransactionHash } from "../utils";
+
+export class MockTransactionData implements ethers.providers.TransactionResponse, ethers.providers.TransactionReceipt {
+  hash: string;
+  blockNumber: number;
+  blockHash: string;
+  timestamp?: number;
+  confirmations: number;
+  from: string;
+  raw?: string;
+  wait: (confirmations?: number) => Promise<ethers.providers.TransactionReceipt>;
+  to: string;
+  nonce: number;
+  gasLimit: ethers.BigNumber;
+  gasPrice?: ethers.BigNumber;
+  data: string;
+  value: ethers.BigNumber;
+  chainId: number;
+  r?: string;
+  s?: string;
+  v?: number;
+  type: number;
+  accessList?: ethers.utils.AccessList;
+  maxPriorityFeePerGas?: ethers.BigNumber;
+  maxFeePerGas?: ethers.BigNumber;
+
+  contractAddress: string;
+  transactionIndex: number;
+  root?: string | undefined;
+  gasUsed: ethers.BigNumber;
+  logsBloom: string;
+  transactionHash: string;
+  logs: ethers.providers.Log[];
+  cumulativeGasUsed: ethers.BigNumber;
+  effectiveGasPrice: ethers.BigNumber;
+  byzantium: boolean;
+  status?: number | undefined;
+
+  constructor() {
+    this.hash = "0x";
+    this.confirmations = 0;
+    this.from = createAddress("0x1234");
+    this.nonce = 1;
+    this.gasLimit = ethers.BigNumber.from(21000);
+    this.data = "0x";
+    this.value = ethers.BigNumber.from(10000);
+    this.chainId = 1;
+    this.to = createAddress("0x256");
+    this.type = 1;
+    this.blockHash = "0x";
+    this.blockNumber = 1;
+    this.timestamp = Date.now();
+
+    this.contractAddress = createAddress("0x789");
+    this.transactionIndex = 0;
+    this.gasUsed = ethers.BigNumber.from(1000);
+    this.logsBloom = "0x";
+    this.transactionHash = "0x";
+    this.logs = [];
+    this.cumulativeGasUsed = ethers.BigNumber.from(1000);
+    this.effectiveGasPrice = ethers.BigNumber.from(1000);
+    this.byzantium = false;
+
+    this.wait = this._wait;
+  }
+
+  private _wait = (confirmations?: number): Promise<ethers.providers.TransactionReceipt> => {
+    return Promise.resolve(this);
+  };
+
+  public setHash(hash: string): MockTransactionData {
+    this.hash = hash;
+    this.transactionHash = hash;
+    return this;
+  }
+
+  public generateHash(): MockTransactionData {
+    const txParams: ethers.UnsignedTransaction = {
+      to: this.to,
+      nonce: this.nonce,
+      gasLimit: this.gasLimit,
+      gasPrice: this.gasPrice,
+      data: this.data,
+      value: ethers.utils.hexlify(this.value),
+      chainId: this.chainId,
+      type: this.type,
+    };
+
+    if (this.maxFeePerGas) txParams.maxFeePerGas = this.maxFeePerGas;
+    if (this.maxPriorityFeePerGas) txParams.maxPriorityFeePerGas = this.maxPriorityFeePerGas;
+
+    this.hash = createTransactionHash(txParams);
+
+    this.transactionHash = this.hash;
+    return this;
+  }
+
+  public setFrom(address: string): MockTransactionData {
+    this.from = address.toLowerCase();
+    return this;
+  }
+
+  public setTo(address: string): MockTransactionData {
+    this.to = address.toLowerCase();
+    return this;
+  }
+
+  public setNonce(value: number): MockTransactionData {
+    this.nonce = value;
+    return this;
+  }
+
+  public setValue(value: string): MockTransactionData {
+    this.value = ethers.BigNumber.from(value);
+    return this;
+  }
+
+  public setGasLimit(value: string): MockTransactionData {
+    this.gasLimit = ethers.BigNumber.from(value);
+    return this;
+  }
+
+  public setGasPrice(value: string): MockTransactionData {
+    this.gasPrice = ethers.BigNumber.from(value);
+    return this;
+  }
+
+  public setData(data: string): MockTransactionData {
+    this.data = data;
+    return this;
+  }
+
+  public setGasUsed(value: string): MockTransactionData {
+    this.gasUsed = ethers.BigNumber.from(value);
+    return this;
+  }
+
+  public setLogsBloom(value: string): MockTransactionData {
+    this.logsBloom = value;
+    return this;
+  }
+
+  public setLogs(logs: ethers.providers.Log[]): MockTransactionData {
+    this.logs = logs;
+    return this;
+  }
+
+  public setBlockNumber(blockNumber: number): MockTransactionData {
+    this.blockNumber = blockNumber;
+    return this;
+  }
+
+  public setTimestamp(timestamp: number): MockTransactionData {
+    this.timestamp = timestamp;
+    return this;
+  }
+
+  public setContractAddress(address: string): MockTransactionData {
+    this.contractAddress = address;
+    return this;
+  }
+
+  public setTransactionIndex(index: number): MockTransactionData {
+    this.transactionIndex = index;
+    return this;
+  }
+
+  public setTransactionHash(hash: string): MockTransactionData {
+    this.transactionHash = hash;
+    return this;
+  }
+
+  public setCumulativeGasUsed(value: string): MockTransactionData {
+    this.cumulativeGasUsed = ethers.BigNumber.from(value);
+    return this;
+  }
+
+  public setEffectiveGasPrice(value: string): MockTransactionData {
+    this.effectiveGasPrice = ethers.BigNumber.from(value);
+    return this;
+  }
+
+  public setByzantium(value: boolean): MockTransactionData {
+    this.byzantium = value;
+    return this;
+  }
+
+  public setStatus(value: number): MockTransactionData {
+    this.status = value;
+    return this;
+  }
+
+  public setBlockHash(hash: string): MockTransactionData {
+    this.blockHash = hash;
+    return this;
+  }
+
+  public setRoot(root: string): MockTransactionData {
+    this.root = root;
+    return this;
+  }
+
+  public setChainId(chainId: number): MockTransactionData {
+    this.chainId = chainId;
+    return this;
+  }
+
+  public setR(r: string): MockTransactionData {
+    this.r = r;
+    return this;
+  }
+
+  public setS(s: string): MockTransactionData {
+    this.s = s;
+    return this;
+  }
+
+  public setV(v: number): MockTransactionData {
+    this.v = v;
+    return this;
+  }
+
+  public setAccessList(accessList: ethers.utils.AccessList): MockTransactionData {
+    this.accessList = accessList;
+    return this;
+  }
+
+  public setMaxPriorityFeePerGas(value: string): MockTransactionData {
+    this.maxPriorityFeePerGas = ethers.BigNumber.from(value);
+    return this;
+  }
+
+  public setMaxFeePerGas(value: string): MockTransactionData {
+    this.maxFeePerGas = ethers.BigNumber.from(value);
+    return this;
+  }
+
+  public setConfirmations(confirmations: number): MockTransactionData {
+    this.confirmations = confirmations;
+    return this;
+  }
+
+  public setRaw(raw: string): MockTransactionData {
+    this.raw = raw;
+    return this;
+  }
+
+  public setTransactionType(type: number): MockTransactionData {
+    this.type = type;
+    return this;
+  }
+
+  public setTransactionResponse(transaction: Partial<ethers.providers.TransactionResponse>): MockTransactionData {
+    this.blockNumber = transaction.blockNumber ? transaction.blockNumber : this.blockNumber;
+    this.blockHash = transaction.blockHash ? transaction.blockHash : this.blockHash;
+    this.timestamp = transaction.timestamp;
+    this.confirmations = transaction.confirmations ? transaction.confirmations : this.confirmations;
+    this.from = transaction.from ? transaction.from : this.from;
+    this.raw = transaction.raw ? transaction.raw : this.raw;
+    this.to = transaction.to ? transaction.to : this.to;
+    this.nonce = transaction.nonce ? transaction.nonce : this.nonce;
+    this.gasLimit = transaction.gasLimit ? transaction.gasLimit : this.gasLimit;
+    this.gasPrice = transaction.gasPrice;
+    this.data = transaction.data ? transaction.data : this.data;
+    this.value = transaction.value ? transaction.value : this.value;
+    this.chainId = transaction.chainId ? transaction.chainId : this.chainId;
+    this.r = transaction.r ? transaction.r : this.r;
+    this.s = transaction.s ? transaction.s : this.s;
+    this.v = transaction.v ? transaction.v : this.v;
+    this.type = transaction.type ? transaction.type : this.type;
+    this.accessList = transaction.accessList ? transaction.accessList : this.accessList;
+    this.maxPriorityFeePerGas = transaction.maxPriorityFeePerGas
+      ? transaction.maxPriorityFeePerGas
+      : this.maxPriorityFeePerGas;
+    this.maxFeePerGas = transaction.maxFeePerGas ? transaction.maxFeePerGas : this.maxFeePerGas;
+
+    if (transaction.hash) this.setHash(transaction.hash);
+    else this.generateHash();
+
+    return this;
+  }
+
+  public setTransactionReceipt(receipt: Partial<ethers.providers.TransactionReceipt>): MockTransactionData {
+    this.to = receipt.to ? receipt.to : this.to;
+    this.from = receipt.from ? receipt.from : this.from;
+    this.contractAddress = receipt.contractAddress ? receipt.contractAddress : this.contractAddress;
+    this.transactionIndex = receipt.transactionIndex ? receipt.transactionIndex : this.transactionIndex;
+    this.root = receipt.root ? receipt.root : this.root;
+    this.gasUsed = receipt.gasUsed ? receipt.gasUsed : this.gasUsed;
+    this.logsBloom = receipt.logsBloom ? receipt.logsBloom : this.logsBloom;
+    this.blockHash = receipt.blockHash ? receipt.blockHash : this.blockHash;
+    this.hash = receipt.transactionHash ? receipt.transactionHash : this.hash;
+    this.logs = receipt.logs ? receipt.logs : this.logs;
+    this.cumulativeGasUsed = receipt.cumulativeGasUsed ? receipt.cumulativeGasUsed : this.cumulativeGasUsed;
+    this.effectiveGasPrice = receipt.effectiveGasPrice ? receipt.effectiveGasPrice : this.effectiveGasPrice;
+    this.byzantium = receipt.byzantium ? receipt.byzantium : this.byzantium;
+    this.type = receipt.type ? receipt.type : this.type;
+    this.status = receipt.status;
+
+    if (receipt.transactionHash) this.setHash(receipt.transactionHash);
+    else this.generateHash();
+
+    return this;
+  }
+
+  public getTransactionResponse(): ethers.providers.TransactionResponse {
+    const transaction: ethers.providers.TransactionResponse = {
+      hash: this.hash,
+      blockNumber: this.blockNumber,
+      blockHash: this.blockHash,
+      timestamp: this.timestamp,
+      confirmations: this.confirmations,
+      from: this.from,
+      raw: this.raw,
+      wait: this.wait,
+      to: this.to,
+      nonce: this.nonce,
+      gasLimit: this.gasLimit,
+      gasPrice: this.gasPrice,
+      data: this.data,
+      value: this.value,
+      chainId: this.chainId,
+      r: this.r,
+      s: this.s,
+      v: this.v,
+      type: this.type,
+      accessList: this.accessList,
+      maxPriorityFeePerGas: this.maxPriorityFeePerGas,
+      maxFeePerGas: this.maxFeePerGas,
+    };
+
+    return transaction;
+  }
+
+  public getTransactionReceipt(): ethers.providers.TransactionReceipt {
+    const receipt: ethers.providers.TransactionReceipt = {
+      to: this.to,
+      from: this.from,
+      contractAddress: this.contractAddress,
+      transactionIndex: this.transactionIndex,
+      root: this.root,
+      gasUsed: this.gasUsed,
+      logsBloom: this.logsBloom,
+      blockHash: this.blockHash,
+      transactionHash: this.transactionHash,
+      logs: this.logs,
+      cumulativeGasUsed: this.cumulativeGasUsed,
+      effectiveGasPrice: this.effectiveGasPrice,
+      byzantium: this.byzantium,
+      type: this.type,
+      status: this.status,
+      blockNumber: this.blockNumber,
+      confirmations: this.confirmations,
+    };
+
+    return receipt;
+  }
+}
+
+export default MockTransactionData;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,12 +4,15 @@ import { ProviderCache, ProviderCacheOptions } from "./provider.cache";
 import CachedContract from "./cached.contract";
 import { MulticallProvider, MulticallContract } from "./multicall.provider";
 import VictimIdentifier from "./victim-identification/victim.identifier";
-import { createTransactionHash } from "./transaction.helper";
 
 export const padAddress = (address: string) => ethers.utils.hexZeroPad(address, 20);
 export const createAddress = (address: string) => padAddress(address).toLowerCase();
 export const createChecksumAddress = (address: string): string => toChecksumAddress(padAddress(address));
 export const toChecksumAddress = (address: string): string => ethers.utils.getAddress(address.toLowerCase());
+export const createTransactionHash = (txParams: ethers.UnsignedTransaction): string => {
+  const tx = ethers.utils.serializeTransaction(txParams);
+  return ethers.utils.keccak256(tx);
+};
 
 export {
   NetworkManager,
@@ -19,5 +22,4 @@ export {
   MulticallProvider,
   MulticallContract,
   VictimIdentifier,
-  createTransactionHash,
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,6 +4,7 @@ import { ProviderCache, ProviderCacheOptions } from "./provider.cache";
 import CachedContract from "./cached.contract";
 import { MulticallProvider, MulticallContract } from "./multicall.provider";
 import VictimIdentifier from "./victim-identification/victim.identifier";
+import { createTransactionHash } from "./transaction.helper";
 
 export const padAddress = (address: string) => ethers.utils.hexZeroPad(address, 20);
 export const createAddress = (address: string) => padAddress(address).toLowerCase();
@@ -18,4 +19,5 @@ export {
   MulticallProvider,
   MulticallContract,
   VictimIdentifier,
+  createTransactionHash,
 };

--- a/src/utils/transaction.helper.ts
+++ b/src/utils/transaction.helper.ts
@@ -1,6 +1,0 @@
-import { ethers } from "forta-agent";
-
-export const createTransactionHash = (txParams: ethers.UnsignedTransaction): string => {
-  const tx = ethers.utils.serializeTransaction(txParams);
-  return ethers.utils.keccak256(tx);
-};

--- a/src/utils/transaction.helper.ts
+++ b/src/utils/transaction.helper.ts
@@ -1,0 +1,6 @@
+import { ethers } from "forta-agent";
+
+export const createTransactionHash = (txParams: ethers.UnsignedTransaction): string => {
+  const tx = ethers.utils.serializeTransaction(txParams);
+  return ethers.utils.keccak256(tx);
+};


### PR DESCRIPTION
- Created a new class called `MockTransactionData` that implements the interfaces `ethers.providers.TransactionResponse` and `ethers.providers.TransactionReceipt`. 
- So this class can be used to create both transaction data that can be used to set up as return values for `getTransaction` and `getTransactionReceipt`.
- The class is instantiated with default values for all the field and there are set functions that can be used to set the values for each of these fields. 
- Updated `MockEthersProvider` with three new methods: 
      - `setTransactionResponse(transaction: MockTransactionData)`: sets the return value for `getTransaction()`
      - `setTransactionReceipt(transaction: MockTransactionData)`: sets the return value for `getTransactionReceipt()`
      - `setTransaction(transaction: MockTransactionData)`: sets the return value for both `getTransaction()` and `getTransactionReceipt()`
- Written test file for `MockTransactionData`
- Written tests for the `MockEthersProvider` to test the new methods
- Executed `npm run test`. All the test suites are passing.
- Updated Readme with the documentation of both `MockTransactionData` and new methods of `MockEthersProvider`

=> Have not changed the version in the package.json yet. 
---> Let me know if any changes should be made. 

Thank You!